### PR TITLE
[codex] Add logging config editor UI

### DIFF
--- a/LotusECMLogger/Controls/LoggingConfigEditorControl.Designer.cs
+++ b/LotusECMLogger/Controls/LoggingConfigEditorControl.Designer.cs
@@ -1,0 +1,667 @@
+namespace LotusECMLogger.Controls
+{
+    partial class LoggingConfigEditorControl
+    {
+        private System.ComponentModel.IContainer? components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                components?.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        private void InitializeComponent()
+        {
+            topButtonPanel = new FlowLayoutPanel();
+            configPickerLabel = new Label();
+            configPickerComboBox = new ComboBox();
+            loadConfigButton = new Button();
+            refreshConfigsButton = new Button();
+            newConfigButton = new Button();
+            saveConfigButton = new Button();
+            saveAsConfigButton = new Button();
+            editorLayout = new TableLayoutPanel();
+            metadataGroupBox = new GroupBox();
+            metadataLayout = new TableLayoutPanel();
+            configNameLabel = new Label();
+            configNameTextBox = new TextBox();
+            configDescriptionLabel = new Label();
+            configDescriptionTextBox = new TextBox();
+            filePathLabel = new Label();
+            filePathValueLabel = new Label();
+            editorSplitContainer = new SplitContainer();
+            ecuGroupBox = new GroupBox();
+            ecuLayout = new TableLayoutPanel();
+            ecuListBox = new ListBox();
+            ecuButtonPanel = new FlowLayoutPanel();
+            addEcuButton = new Button();
+            removeEcuButton = new Button();
+            requestEditorLayout = new TableLayoutPanel();
+            ecuDetailsGroupBox = new GroupBox();
+            ecuDetailsLayout = new TableLayoutPanel();
+            ecuNameLabel = new Label();
+            ecuNameTextBox = new TextBox();
+            requestIdLabel = new Label();
+            requestIdTextBox = new TextBox();
+            responseIdLabel = new Label();
+            responseIdTextBox = new TextBox();
+            requestsGroupBox = new GroupBox();
+            requestsLayout = new TableLayoutPanel();
+            requestButtonsPanel = new FlowLayoutPanel();
+            addMode01Button = new Button();
+            addMode22Button = new Button();
+            removeRequestButton = new Button();
+            moveRequestUpButton = new Button();
+            moveRequestDownButton = new Button();
+            requestsDataGridView = new DataGridView();
+            requestHelpLabel = new Label();
+            topButtonPanel.SuspendLayout();
+            editorLayout.SuspendLayout();
+            metadataGroupBox.SuspendLayout();
+            metadataLayout.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)editorSplitContainer).BeginInit();
+            editorSplitContainer.Panel1.SuspendLayout();
+            editorSplitContainer.Panel2.SuspendLayout();
+            editorSplitContainer.SuspendLayout();
+            ecuGroupBox.SuspendLayout();
+            ecuLayout.SuspendLayout();
+            ecuButtonPanel.SuspendLayout();
+            requestEditorLayout.SuspendLayout();
+            ecuDetailsGroupBox.SuspendLayout();
+            ecuDetailsLayout.SuspendLayout();
+            requestsGroupBox.SuspendLayout();
+            requestsLayout.SuspendLayout();
+            requestButtonsPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)requestsDataGridView).BeginInit();
+            SuspendLayout();
+            //
+            // topButtonPanel
+            //
+            topButtonPanel.AutoSize = true;
+            topButtonPanel.Controls.Add(configPickerLabel);
+            topButtonPanel.Controls.Add(configPickerComboBox);
+            topButtonPanel.Controls.Add(loadConfigButton);
+            topButtonPanel.Controls.Add(refreshConfigsButton);
+            topButtonPanel.Controls.Add(newConfigButton);
+            topButtonPanel.Controls.Add(saveConfigButton);
+            topButtonPanel.Controls.Add(saveAsConfigButton);
+            topButtonPanel.Dock = DockStyle.Fill;
+            topButtonPanel.Location = new Point(3, 3);
+            topButtonPanel.Name = "topButtonPanel";
+            topButtonPanel.Padding = new Padding(0, 4, 0, 4);
+            topButtonPanel.Size = new Size(986, 44);
+            topButtonPanel.TabIndex = 0;
+            topButtonPanel.WrapContents = false;
+            //
+            // configPickerLabel
+            //
+            configPickerLabel.Anchor = AnchorStyles.Left;
+            configPickerLabel.AutoSize = true;
+            configPickerLabel.Location = new Point(3, 10);
+            configPickerLabel.Name = "configPickerLabel";
+            configPickerLabel.Size = new Size(93, 25);
+            configPickerLabel.TabIndex = 0;
+            configPickerLabel.Text = "Load config";
+            //
+            // configPickerComboBox
+            //
+            configPickerComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
+            configPickerComboBox.FormattingEnabled = true;
+            configPickerComboBox.Location = new Point(102, 7);
+            configPickerComboBox.Name = "configPickerComboBox";
+            configPickerComboBox.Size = new Size(250, 33);
+            configPickerComboBox.TabIndex = 1;
+            //
+            // loadConfigButton
+            //
+            loadConfigButton.Location = new Point(358, 7);
+            loadConfigButton.Name = "loadConfigButton";
+            loadConfigButton.Size = new Size(90, 34);
+            loadConfigButton.TabIndex = 2;
+            loadConfigButton.Text = "Load";
+            loadConfigButton.UseVisualStyleBackColor = true;
+            loadConfigButton.Click += LoadConfigButton_Click;
+            //
+            // refreshConfigsButton
+            //
+            refreshConfigsButton.Location = new Point(454, 7);
+            refreshConfigsButton.Name = "refreshConfigsButton";
+            refreshConfigsButton.Size = new Size(90, 34);
+            refreshConfigsButton.TabIndex = 3;
+            refreshConfigsButton.Text = "Refresh";
+            refreshConfigsButton.UseVisualStyleBackColor = true;
+            refreshConfigsButton.Click += RefreshConfigsButton_Click;
+            //
+            // newConfigButton
+            //
+            newConfigButton.Location = new Point(550, 7);
+            newConfigButton.Name = "newConfigButton";
+            newConfigButton.Size = new Size(90, 34);
+            newConfigButton.TabIndex = 4;
+            newConfigButton.Text = "New";
+            newConfigButton.UseVisualStyleBackColor = true;
+            newConfigButton.Click += NewConfigButton_Click;
+            //
+            // saveConfigButton
+            //
+            saveConfigButton.Location = new Point(646, 7);
+            saveConfigButton.Name = "saveConfigButton";
+            saveConfigButton.Size = new Size(90, 34);
+            saveConfigButton.TabIndex = 5;
+            saveConfigButton.Text = "Save";
+            saveConfigButton.UseVisualStyleBackColor = true;
+            saveConfigButton.Click += SaveConfigButton_Click;
+            //
+            // saveAsConfigButton
+            //
+            saveAsConfigButton.Location = new Point(742, 7);
+            saveAsConfigButton.Name = "saveAsConfigButton";
+            saveAsConfigButton.Size = new Size(90, 34);
+            saveAsConfigButton.TabIndex = 6;
+            saveAsConfigButton.Text = "Save As";
+            saveAsConfigButton.UseVisualStyleBackColor = true;
+            saveAsConfigButton.Click += SaveAsConfigButton_Click;
+            //
+            // editorLayout
+            //
+            editorLayout.ColumnCount = 1;
+            editorLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            editorLayout.Controls.Add(topButtonPanel, 0, 0);
+            editorLayout.Controls.Add(metadataGroupBox, 0, 1);
+            editorLayout.Controls.Add(editorSplitContainer, 0, 2);
+            editorLayout.Dock = DockStyle.Fill;
+            editorLayout.Location = new Point(0, 0);
+            editorLayout.Name = "editorLayout";
+            editorLayout.RowCount = 3;
+            editorLayout.RowStyles.Add(new RowStyle());
+            editorLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 130F));
+            editorLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            editorLayout.Size = new Size(992, 643);
+            editorLayout.TabIndex = 0;
+            //
+            // metadataGroupBox
+            //
+            metadataGroupBox.Controls.Add(metadataLayout);
+            metadataGroupBox.Dock = DockStyle.Fill;
+            metadataGroupBox.Location = new Point(3, 53);
+            metadataGroupBox.Name = "metadataGroupBox";
+            metadataGroupBox.Size = new Size(986, 124);
+            metadataGroupBox.TabIndex = 1;
+            metadataGroupBox.TabStop = false;
+            metadataGroupBox.Text = "Configuration Details";
+            //
+            // metadataLayout
+            //
+            metadataLayout.ColumnCount = 2;
+            metadataLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 140F));
+            metadataLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            metadataLayout.Controls.Add(configNameLabel, 0, 0);
+            metadataLayout.Controls.Add(configNameTextBox, 1, 0);
+            metadataLayout.Controls.Add(configDescriptionLabel, 0, 1);
+            metadataLayout.Controls.Add(configDescriptionTextBox, 1, 1);
+            metadataLayout.Controls.Add(filePathLabel, 0, 2);
+            metadataLayout.Controls.Add(filePathValueLabel, 1, 2);
+            metadataLayout.Dock = DockStyle.Fill;
+            metadataLayout.Location = new Point(3, 27);
+            metadataLayout.Name = "metadataLayout";
+            metadataLayout.RowCount = 3;
+            metadataLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 36F));
+            metadataLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            metadataLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
+            metadataLayout.Size = new Size(980, 94);
+            metadataLayout.TabIndex = 0;
+            //
+            // configNameLabel
+            //
+            configNameLabel.Anchor = AnchorStyles.Left;
+            configNameLabel.AutoSize = true;
+            configNameLabel.Location = new Point(3, 5);
+            configNameLabel.Name = "configNameLabel";
+            configNameLabel.Size = new Size(60, 25);
+            configNameLabel.TabIndex = 0;
+            configNameLabel.Text = "Name";
+            //
+            // configNameTextBox
+            //
+            configNameTextBox.Dock = DockStyle.Fill;
+            configNameTextBox.Location = new Point(143, 3);
+            configNameTextBox.Name = "configNameTextBox";
+            configNameTextBox.Size = new Size(834, 31);
+            configNameTextBox.TabIndex = 1;
+            configNameTextBox.TextChanged += EditorField_TextChanged;
+            //
+            // configDescriptionLabel
+            //
+            configDescriptionLabel.Anchor = AnchorStyles.Left;
+            configDescriptionLabel.AutoSize = true;
+            configDescriptionLabel.Location = new Point(3, 38);
+            configDescriptionLabel.Name = "configDescriptionLabel";
+            configDescriptionLabel.Size = new Size(102, 25);
+            configDescriptionLabel.TabIndex = 2;
+            configDescriptionLabel.Text = "Description";
+            //
+            // configDescriptionTextBox
+            //
+            configDescriptionTextBox.Dock = DockStyle.Fill;
+            configDescriptionTextBox.Location = new Point(143, 39);
+            configDescriptionTextBox.Multiline = true;
+            configDescriptionTextBox.Name = "configDescriptionTextBox";
+            configDescriptionTextBox.Size = new Size(834, 24);
+            configDescriptionTextBox.TabIndex = 3;
+            configDescriptionTextBox.TextChanged += EditorField_TextChanged;
+            //
+            // filePathLabel
+            //
+            filePathLabel.Anchor = AnchorStyles.Left;
+            filePathLabel.AutoSize = true;
+            filePathLabel.Location = new Point(3, 68);
+            filePathLabel.Name = "filePathLabel";
+            filePathLabel.Size = new Size(74, 25);
+            filePathLabel.TabIndex = 4;
+            filePathLabel.Text = "File path";
+            //
+            // filePathValueLabel
+            //
+            filePathValueLabel.Anchor = AnchorStyles.Left;
+            filePathValueLabel.AutoEllipsis = true;
+            filePathValueLabel.AutoSize = true;
+            filePathValueLabel.Location = new Point(143, 68);
+            filePathValueLabel.Name = "filePathValueLabel";
+            filePathValueLabel.Size = new Size(74, 25);
+            filePathValueLabel.TabIndex = 5;
+            filePathValueLabel.Text = "Unsaved";
+            //
+            // editorSplitContainer
+            //
+            editorSplitContainer.Dock = DockStyle.Fill;
+            editorSplitContainer.Location = new Point(3, 183);
+            editorSplitContainer.Name = "editorSplitContainer";
+            //
+            // editorSplitContainer.Panel1
+            //
+            editorSplitContainer.Panel1.Controls.Add(ecuGroupBox);
+            //
+            // editorSplitContainer.Panel2
+            //
+            editorSplitContainer.Panel2.Controls.Add(requestEditorLayout);
+            editorSplitContainer.Size = new Size(986, 457);
+            editorSplitContainer.SplitterDistance = 255;
+            editorSplitContainer.TabIndex = 2;
+            //
+            // ecuGroupBox
+            //
+            ecuGroupBox.Controls.Add(ecuLayout);
+            ecuGroupBox.Dock = DockStyle.Fill;
+            ecuGroupBox.Location = new Point(0, 0);
+            ecuGroupBox.Name = "ecuGroupBox";
+            ecuGroupBox.Size = new Size(255, 457);
+            ecuGroupBox.TabIndex = 0;
+            ecuGroupBox.TabStop = false;
+            ecuGroupBox.Text = "ECUs";
+            //
+            // ecuLayout
+            //
+            ecuLayout.ColumnCount = 1;
+            ecuLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            ecuLayout.Controls.Add(ecuListBox, 0, 0);
+            ecuLayout.Controls.Add(ecuButtonPanel, 0, 1);
+            ecuLayout.Dock = DockStyle.Fill;
+            ecuLayout.Location = new Point(3, 27);
+            ecuLayout.Name = "ecuLayout";
+            ecuLayout.RowCount = 2;
+            ecuLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            ecuLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 46F));
+            ecuLayout.Size = new Size(249, 427);
+            ecuLayout.TabIndex = 0;
+            //
+            // ecuListBox
+            //
+            ecuListBox.Dock = DockStyle.Fill;
+            ecuListBox.FormattingEnabled = true;
+            ecuListBox.ItemHeight = 25;
+            ecuListBox.Location = new Point(3, 3);
+            ecuListBox.Name = "ecuListBox";
+            ecuListBox.Size = new Size(243, 375);
+            ecuListBox.TabIndex = 0;
+            ecuListBox.SelectedIndexChanged += EcuListBox_SelectedIndexChanged;
+            //
+            // ecuButtonPanel
+            //
+            ecuButtonPanel.Controls.Add(addEcuButton);
+            ecuButtonPanel.Controls.Add(removeEcuButton);
+            ecuButtonPanel.Dock = DockStyle.Fill;
+            ecuButtonPanel.Location = new Point(3, 384);
+            ecuButtonPanel.Name = "ecuButtonPanel";
+            ecuButtonPanel.Size = new Size(243, 40);
+            ecuButtonPanel.TabIndex = 1;
+            ecuButtonPanel.WrapContents = false;
+            //
+            // addEcuButton
+            //
+            addEcuButton.Location = new Point(3, 3);
+            addEcuButton.Name = "addEcuButton";
+            addEcuButton.Size = new Size(90, 34);
+            addEcuButton.TabIndex = 0;
+            addEcuButton.Text = "Add ECU";
+            addEcuButton.UseVisualStyleBackColor = true;
+            addEcuButton.Click += AddEcuButton_Click;
+            //
+            // removeEcuButton
+            //
+            removeEcuButton.Location = new Point(99, 3);
+            removeEcuButton.Name = "removeEcuButton";
+            removeEcuButton.Size = new Size(120, 34);
+            removeEcuButton.TabIndex = 1;
+            removeEcuButton.Text = "Remove ECU";
+            removeEcuButton.UseVisualStyleBackColor = true;
+            removeEcuButton.Click += RemoveEcuButton_Click;
+            //
+            // requestEditorLayout
+            //
+            requestEditorLayout.ColumnCount = 1;
+            requestEditorLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            requestEditorLayout.Controls.Add(ecuDetailsGroupBox, 0, 0);
+            requestEditorLayout.Controls.Add(requestsGroupBox, 0, 1);
+            requestEditorLayout.Dock = DockStyle.Fill;
+            requestEditorLayout.Location = new Point(0, 0);
+            requestEditorLayout.Name = "requestEditorLayout";
+            requestEditorLayout.RowCount = 2;
+            requestEditorLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 110F));
+            requestEditorLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            requestEditorLayout.Size = new Size(727, 457);
+            requestEditorLayout.TabIndex = 0;
+            //
+            // ecuDetailsGroupBox
+            //
+            ecuDetailsGroupBox.Controls.Add(ecuDetailsLayout);
+            ecuDetailsGroupBox.Dock = DockStyle.Fill;
+            ecuDetailsGroupBox.Location = new Point(3, 3);
+            ecuDetailsGroupBox.Name = "ecuDetailsGroupBox";
+            ecuDetailsGroupBox.Size = new Size(721, 104);
+            ecuDetailsGroupBox.TabIndex = 0;
+            ecuDetailsGroupBox.TabStop = false;
+            ecuDetailsGroupBox.Text = "Selected ECU";
+            //
+            // ecuDetailsLayout
+            //
+            ecuDetailsLayout.ColumnCount = 2;
+            ecuDetailsLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 140F));
+            ecuDetailsLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            ecuDetailsLayout.Controls.Add(ecuNameLabel, 0, 0);
+            ecuDetailsLayout.Controls.Add(ecuNameTextBox, 1, 0);
+            ecuDetailsLayout.Controls.Add(requestIdLabel, 0, 1);
+            ecuDetailsLayout.Controls.Add(requestIdTextBox, 1, 1);
+            ecuDetailsLayout.Controls.Add(responseIdLabel, 0, 2);
+            ecuDetailsLayout.Controls.Add(responseIdTextBox, 1, 2);
+            ecuDetailsLayout.Dock = DockStyle.Fill;
+            ecuDetailsLayout.Location = new Point(3, 27);
+            ecuDetailsLayout.Name = "ecuDetailsLayout";
+            ecuDetailsLayout.RowCount = 3;
+            ecuDetailsLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 33.3333321F));
+            ecuDetailsLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 33.3333321F));
+            ecuDetailsLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 33.3333321F));
+            ecuDetailsLayout.Size = new Size(715, 74);
+            ecuDetailsLayout.TabIndex = 0;
+            //
+            // ecuNameLabel
+            //
+            ecuNameLabel.Anchor = AnchorStyles.Left;
+            ecuNameLabel.AutoSize = true;
+            ecuNameLabel.Location = new Point(3, 0);
+            ecuNameLabel.Name = "ecuNameLabel";
+            ecuNameLabel.Size = new Size(91, 24);
+            ecuNameLabel.TabIndex = 0;
+            ecuNameLabel.Text = "ECU name";
+            //
+            // ecuNameTextBox
+            //
+            ecuNameTextBox.Dock = DockStyle.Fill;
+            ecuNameTextBox.Location = new Point(143, 3);
+            ecuNameTextBox.Name = "ecuNameTextBox";
+            ecuNameTextBox.Size = new Size(569, 31);
+            ecuNameTextBox.TabIndex = 1;
+            ecuNameTextBox.TextChanged += EditorField_TextChanged;
+            //
+            // requestIdLabel
+            //
+            requestIdLabel.Anchor = AnchorStyles.Left;
+            requestIdLabel.AutoSize = true;
+            requestIdLabel.Location = new Point(3, 24);
+            requestIdLabel.Name = "requestIdLabel";
+            requestIdLabel.Size = new Size(128, 24);
+            requestIdLabel.TabIndex = 2;
+            requestIdLabel.Text = "Request ID (hex)";
+            //
+            // requestIdTextBox
+            //
+            requestIdTextBox.Dock = DockStyle.Fill;
+            requestIdTextBox.Location = new Point(143, 27);
+            requestIdTextBox.Name = "requestIdTextBox";
+            requestIdTextBox.Size = new Size(569, 31);
+            requestIdTextBox.TabIndex = 3;
+            requestIdTextBox.TextChanged += EditorField_TextChanged;
+            //
+            // responseIdLabel
+            //
+            responseIdLabel.Anchor = AnchorStyles.Left;
+            responseIdLabel.AutoSize = true;
+            responseIdLabel.Location = new Point(3, 49);
+            responseIdLabel.Name = "responseIdLabel";
+            responseIdLabel.Size = new Size(137, 25);
+            responseIdLabel.TabIndex = 4;
+            responseIdLabel.Text = "Response ID (hex)";
+            //
+            // responseIdTextBox
+            //
+            responseIdTextBox.Dock = DockStyle.Fill;
+            responseIdTextBox.Location = new Point(143, 51);
+            responseIdTextBox.Name = "responseIdTextBox";
+            responseIdTextBox.Size = new Size(569, 31);
+            responseIdTextBox.TabIndex = 5;
+            responseIdTextBox.TextChanged += EditorField_TextChanged;
+            //
+            // requestsGroupBox
+            //
+            requestsGroupBox.Controls.Add(requestsLayout);
+            requestsGroupBox.Dock = DockStyle.Fill;
+            requestsGroupBox.Location = new Point(3, 113);
+            requestsGroupBox.Name = "requestsGroupBox";
+            requestsGroupBox.Size = new Size(721, 341);
+            requestsGroupBox.TabIndex = 1;
+            requestsGroupBox.TabStop = false;
+            requestsGroupBox.Text = "Requests";
+            //
+            // requestsLayout
+            //
+            requestsLayout.ColumnCount = 1;
+            requestsLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            requestsLayout.Controls.Add(requestButtonsPanel, 0, 0);
+            requestsLayout.Controls.Add(requestsDataGridView, 0, 1);
+            requestsLayout.Controls.Add(requestHelpLabel, 0, 2);
+            requestsLayout.Dock = DockStyle.Fill;
+            requestsLayout.Location = new Point(3, 27);
+            requestsLayout.Name = "requestsLayout";
+            requestsLayout.RowCount = 3;
+            requestsLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 42F));
+            requestsLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            requestsLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 36F));
+            requestsLayout.Size = new Size(715, 311);
+            requestsLayout.TabIndex = 0;
+            //
+            // requestButtonsPanel
+            //
+            requestButtonsPanel.Controls.Add(addMode01Button);
+            requestButtonsPanel.Controls.Add(addMode22Button);
+            requestButtonsPanel.Controls.Add(removeRequestButton);
+            requestButtonsPanel.Controls.Add(moveRequestUpButton);
+            requestButtonsPanel.Controls.Add(moveRequestDownButton);
+            requestButtonsPanel.Dock = DockStyle.Fill;
+            requestButtonsPanel.Location = new Point(3, 3);
+            requestButtonsPanel.Name = "requestButtonsPanel";
+            requestButtonsPanel.Size = new Size(709, 36);
+            requestButtonsPanel.TabIndex = 0;
+            requestButtonsPanel.WrapContents = false;
+            //
+            // addMode01Button
+            //
+            addMode01Button.Location = new Point(3, 3);
+            addMode01Button.Name = "addMode01Button";
+            addMode01Button.Size = new Size(118, 30);
+            addMode01Button.TabIndex = 0;
+            addMode01Button.Text = "Add Mode01";
+            addMode01Button.UseVisualStyleBackColor = true;
+            addMode01Button.Click += AddMode01Button_Click;
+            //
+            // addMode22Button
+            //
+            addMode22Button.Location = new Point(127, 3);
+            addMode22Button.Name = "addMode22Button";
+            addMode22Button.Size = new Size(118, 30);
+            addMode22Button.TabIndex = 1;
+            addMode22Button.Text = "Add Mode22";
+            addMode22Button.UseVisualStyleBackColor = true;
+            addMode22Button.Click += AddMode22Button_Click;
+            //
+            // removeRequestButton
+            //
+            removeRequestButton.Location = new Point(251, 3);
+            removeRequestButton.Name = "removeRequestButton";
+            removeRequestButton.Size = new Size(138, 30);
+            removeRequestButton.TabIndex = 2;
+            removeRequestButton.Text = "Remove Request";
+            removeRequestButton.UseVisualStyleBackColor = true;
+            removeRequestButton.Click += RemoveRequestButton_Click;
+            //
+            // moveRequestUpButton
+            //
+            moveRequestUpButton.Location = new Point(395, 3);
+            moveRequestUpButton.Name = "moveRequestUpButton";
+            moveRequestUpButton.Size = new Size(89, 30);
+            moveRequestUpButton.TabIndex = 3;
+            moveRequestUpButton.Text = "Move Up";
+            moveRequestUpButton.UseVisualStyleBackColor = true;
+            moveRequestUpButton.Click += MoveRequestUpButton_Click;
+            //
+            // moveRequestDownButton
+            //
+            moveRequestDownButton.Location = new Point(490, 3);
+            moveRequestDownButton.Name = "moveRequestDownButton";
+            moveRequestDownButton.Size = new Size(109, 30);
+            moveRequestDownButton.TabIndex = 4;
+            moveRequestDownButton.Text = "Move Down";
+            moveRequestDownButton.UseVisualStyleBackColor = true;
+            moveRequestDownButton.Click += MoveRequestDownButton_Click;
+            //
+            // requestsDataGridView
+            //
+            requestsDataGridView.AllowUserToAddRows = false;
+            requestsDataGridView.AllowUserToDeleteRows = false;
+            requestsDataGridView.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
+            requestsDataGridView.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            requestsDataGridView.Dock = DockStyle.Fill;
+            requestsDataGridView.Location = new Point(3, 45);
+            requestsDataGridView.MultiSelect = false;
+            requestsDataGridView.Name = "requestsDataGridView";
+            requestsDataGridView.RowHeadersWidth = 62;
+            requestsDataGridView.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
+            requestsDataGridView.Size = new Size(709, 227);
+            requestsDataGridView.TabIndex = 1;
+            requestsDataGridView.CellValueChanged += RequestsDataGridView_CellValueChanged;
+            requestsDataGridView.CurrentCellDirtyStateChanged += RequestsDataGridView_CurrentCellDirtyStateChanged;
+            requestsDataGridView.UserDeletingRow += RequestsDataGridView_UserDeletingRow;
+            //
+            // requestHelpLabel
+            //
+            requestHelpLabel.Anchor = AnchorStyles.Left;
+            requestHelpLabel.AutoSize = true;
+            requestHelpLabel.Location = new Point(3, 281);
+            requestHelpLabel.Name = "requestHelpLabel";
+            requestHelpLabel.Size = new Size(558, 25);
+            requestHelpLabel.TabIndex = 2;
+            requestHelpLabel.Text = "Mode01 uses the PIDs column. Mode22 uses PID High and PID Low values.";
+            //
+            // LoggingConfigEditorControl
+            //
+            AutoScaleDimensions = new SizeF(10F, 25F);
+            AutoScaleMode = AutoScaleMode.Font;
+            Controls.Add(editorLayout);
+            Name = "LoggingConfigEditorControl";
+            Size = new Size(992, 643);
+            topButtonPanel.ResumeLayout(false);
+            topButtonPanel.PerformLayout();
+            editorLayout.ResumeLayout(false);
+            editorLayout.PerformLayout();
+            metadataGroupBox.ResumeLayout(false);
+            metadataLayout.ResumeLayout(false);
+            metadataLayout.PerformLayout();
+            editorSplitContainer.Panel1.ResumeLayout(false);
+            editorSplitContainer.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)editorSplitContainer).EndInit();
+            editorSplitContainer.ResumeLayout(false);
+            ecuGroupBox.ResumeLayout(false);
+            ecuLayout.ResumeLayout(false);
+            ecuButtonPanel.ResumeLayout(false);
+            requestEditorLayout.ResumeLayout(false);
+            ecuDetailsGroupBox.ResumeLayout(false);
+            ecuDetailsLayout.ResumeLayout(false);
+            ecuDetailsLayout.PerformLayout();
+            requestsGroupBox.ResumeLayout(false);
+            requestsLayout.ResumeLayout(false);
+            requestsLayout.PerformLayout();
+            requestButtonsPanel.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)requestsDataGridView).EndInit();
+            ResumeLayout(false);
+        }
+
+        #endregion
+
+        private FlowLayoutPanel topButtonPanel;
+        private Label configPickerLabel;
+        private ComboBox configPickerComboBox;
+        private Button loadConfigButton;
+        private Button refreshConfigsButton;
+        private Button newConfigButton;
+        private Button saveConfigButton;
+        private Button saveAsConfigButton;
+        private TableLayoutPanel editorLayout;
+        private GroupBox metadataGroupBox;
+        private TableLayoutPanel metadataLayout;
+        private Label configNameLabel;
+        private TextBox configNameTextBox;
+        private Label configDescriptionLabel;
+        private TextBox configDescriptionTextBox;
+        private Label filePathLabel;
+        private Label filePathValueLabel;
+        private SplitContainer editorSplitContainer;
+        private GroupBox ecuGroupBox;
+        private TableLayoutPanel ecuLayout;
+        private ListBox ecuListBox;
+        private FlowLayoutPanel ecuButtonPanel;
+        private Button addEcuButton;
+        private Button removeEcuButton;
+        private TableLayoutPanel requestEditorLayout;
+        private GroupBox ecuDetailsGroupBox;
+        private TableLayoutPanel ecuDetailsLayout;
+        private Label ecuNameLabel;
+        private TextBox ecuNameTextBox;
+        private Label requestIdLabel;
+        private TextBox requestIdTextBox;
+        private Label responseIdLabel;
+        private TextBox responseIdTextBox;
+        private GroupBox requestsGroupBox;
+        private TableLayoutPanel requestsLayout;
+        private FlowLayoutPanel requestButtonsPanel;
+        private Button addMode01Button;
+        private Button addMode22Button;
+        private Button removeRequestButton;
+        private Button moveRequestUpButton;
+        private Button moveRequestDownButton;
+        private DataGridView requestsDataGridView;
+        private Label requestHelpLabel;
+    }
+}

--- a/LotusECMLogger/Controls/LoggingConfigEditorControl.Designer.cs
+++ b/LotusECMLogger/Controls/LoggingConfigEditorControl.Designer.cs
@@ -20,7 +20,6 @@ namespace LotusECMLogger.Controls
             topButtonPanel = new FlowLayoutPanel();
             configPickerLabel = new Label();
             configPickerComboBox = new ComboBox();
-            loadConfigButton = new Button();
             refreshConfigsButton = new Button();
             newConfigButton = new Button();
             saveConfigButton = new Button();
@@ -33,7 +32,7 @@ namespace LotusECMLogger.Controls
             configDescriptionLabel = new Label();
             configDescriptionTextBox = new TextBox();
             filePathLabel = new Label();
-            filePathValueLabel = new Label();
+            filePathValueTextBox = new TextBox();
             editorSplitContainer = new SplitContainer();
             ecuGroupBox = new GroupBox();
             ecuLayout = new TableLayoutPanel();
@@ -53,8 +52,7 @@ namespace LotusECMLogger.Controls
             requestsGroupBox = new GroupBox();
             requestsLayout = new TableLayoutPanel();
             requestButtonsPanel = new FlowLayoutPanel();
-            addMode01Button = new Button();
-            addMode22Button = new Button();
+            addRequestButton = new Button();
             removeRequestButton = new Button();
             moveRequestUpButton = new Button();
             moveRequestDownButton = new Button();
@@ -85,7 +83,6 @@ namespace LotusECMLogger.Controls
             topButtonPanel.AutoSize = true;
             topButtonPanel.Controls.Add(configPickerLabel);
             topButtonPanel.Controls.Add(configPickerComboBox);
-            topButtonPanel.Controls.Add(loadConfigButton);
             topButtonPanel.Controls.Add(refreshConfigsButton);
             topButtonPanel.Controls.Add(newConfigButton);
             topButtonPanel.Controls.Add(saveConfigButton);
@@ -116,53 +113,44 @@ namespace LotusECMLogger.Controls
             configPickerComboBox.Name = "configPickerComboBox";
             configPickerComboBox.Size = new Size(250, 33);
             configPickerComboBox.TabIndex = 1;
-            //
-            // loadConfigButton
-            //
-            loadConfigButton.Location = new Point(358, 7);
-            loadConfigButton.Name = "loadConfigButton";
-            loadConfigButton.Size = new Size(90, 34);
-            loadConfigButton.TabIndex = 2;
-            loadConfigButton.Text = "Load";
-            loadConfigButton.UseVisualStyleBackColor = true;
-            loadConfigButton.Click += LoadConfigButton_Click;
+            configPickerComboBox.SelectedIndexChanged += ConfigPickerComboBox_SelectedIndexChanged;
             //
             // refreshConfigsButton
             //
-            refreshConfigsButton.Location = new Point(454, 7);
+            refreshConfigsButton.Location = new Point(358, 7);
             refreshConfigsButton.Name = "refreshConfigsButton";
             refreshConfigsButton.Size = new Size(90, 34);
-            refreshConfigsButton.TabIndex = 3;
+            refreshConfigsButton.TabIndex = 2;
             refreshConfigsButton.Text = "Refresh";
             refreshConfigsButton.UseVisualStyleBackColor = true;
             refreshConfigsButton.Click += RefreshConfigsButton_Click;
             //
             // newConfigButton
             //
-            newConfigButton.Location = new Point(550, 7);
+            newConfigButton.Location = new Point(454, 7);
             newConfigButton.Name = "newConfigButton";
             newConfigButton.Size = new Size(90, 34);
-            newConfigButton.TabIndex = 4;
+            newConfigButton.TabIndex = 3;
             newConfigButton.Text = "New";
             newConfigButton.UseVisualStyleBackColor = true;
             newConfigButton.Click += NewConfigButton_Click;
             //
             // saveConfigButton
             //
-            saveConfigButton.Location = new Point(646, 7);
+            saveConfigButton.Location = new Point(550, 7);
             saveConfigButton.Name = "saveConfigButton";
             saveConfigButton.Size = new Size(90, 34);
-            saveConfigButton.TabIndex = 5;
+            saveConfigButton.TabIndex = 4;
             saveConfigButton.Text = "Save";
             saveConfigButton.UseVisualStyleBackColor = true;
             saveConfigButton.Click += SaveConfigButton_Click;
             //
             // saveAsConfigButton
             //
-            saveAsConfigButton.Location = new Point(742, 7);
+            saveAsConfigButton.Location = new Point(646, 7);
             saveAsConfigButton.Name = "saveAsConfigButton";
             saveAsConfigButton.Size = new Size(90, 34);
-            saveAsConfigButton.TabIndex = 6;
+            saveAsConfigButton.TabIndex = 5;
             saveAsConfigButton.Text = "Save As";
             saveAsConfigButton.UseVisualStyleBackColor = true;
             saveAsConfigButton.Click += SaveAsConfigButton_Click;
@@ -179,7 +167,7 @@ namespace LotusECMLogger.Controls
             editorLayout.Name = "editorLayout";
             editorLayout.RowCount = 3;
             editorLayout.RowStyles.Add(new RowStyle());
-            editorLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 130F));
+            editorLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 176F));
             editorLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
             editorLayout.Size = new Size(992, 643);
             editorLayout.TabIndex = 0;
@@ -190,7 +178,7 @@ namespace LotusECMLogger.Controls
             metadataGroupBox.Dock = DockStyle.Fill;
             metadataGroupBox.Location = new Point(3, 53);
             metadataGroupBox.Name = "metadataGroupBox";
-            metadataGroupBox.Size = new Size(986, 124);
+            metadataGroupBox.Size = new Size(986, 170);
             metadataGroupBox.TabIndex = 1;
             metadataGroupBox.TabStop = false;
             metadataGroupBox.Text = "Configuration Details";
@@ -205,15 +193,15 @@ namespace LotusECMLogger.Controls
             metadataLayout.Controls.Add(configDescriptionLabel, 0, 1);
             metadataLayout.Controls.Add(configDescriptionTextBox, 1, 1);
             metadataLayout.Controls.Add(filePathLabel, 0, 2);
-            metadataLayout.Controls.Add(filePathValueLabel, 1, 2);
+            metadataLayout.Controls.Add(filePathValueTextBox, 1, 2);
             metadataLayout.Dock = DockStyle.Fill;
             metadataLayout.Location = new Point(3, 27);
             metadataLayout.Name = "metadataLayout";
             metadataLayout.RowCount = 3;
+            metadataLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 38F));
+            metadataLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 62F));
             metadataLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 36F));
-            metadataLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-            metadataLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
-            metadataLayout.Size = new Size(980, 94);
+            metadataLayout.Size = new Size(980, 140);
             metadataLayout.TabIndex = 0;
             //
             // configNameLabel
@@ -248,10 +236,11 @@ namespace LotusECMLogger.Controls
             // configDescriptionTextBox
             //
             configDescriptionTextBox.Dock = DockStyle.Fill;
-            configDescriptionTextBox.Location = new Point(143, 39);
+            configDescriptionTextBox.Location = new Point(143, 41);
             configDescriptionTextBox.Multiline = true;
             configDescriptionTextBox.Name = "configDescriptionTextBox";
-            configDescriptionTextBox.Size = new Size(834, 24);
+            configDescriptionTextBox.ScrollBars = ScrollBars.Vertical;
+            configDescriptionTextBox.Size = new Size(834, 56);
             configDescriptionTextBox.TabIndex = 3;
             configDescriptionTextBox.TextChanged += EditorField_TextChanged;
             //
@@ -259,27 +248,31 @@ namespace LotusECMLogger.Controls
             //
             filePathLabel.Anchor = AnchorStyles.Left;
             filePathLabel.AutoSize = true;
-            filePathLabel.Location = new Point(3, 68);
+            filePathLabel.Location = new Point(3, 103);
             filePathLabel.Name = "filePathLabel";
             filePathLabel.Size = new Size(74, 25);
             filePathLabel.TabIndex = 4;
             filePathLabel.Text = "File path";
             //
-            // filePathValueLabel
+            // filePathValueTextBox
             //
-            filePathValueLabel.Anchor = AnchorStyles.Left;
-            filePathValueLabel.AutoEllipsis = true;
-            filePathValueLabel.AutoSize = true;
-            filePathValueLabel.Location = new Point(143, 68);
-            filePathValueLabel.Name = "filePathValueLabel";
-            filePathValueLabel.Size = new Size(74, 25);
-            filePathValueLabel.TabIndex = 5;
-            filePathValueLabel.Text = "Unsaved";
+            filePathValueTextBox.Dock = DockStyle.Fill;
+            filePathValueTextBox.Location = new Point(143, 103);
+            filePathValueTextBox.Margin = new Padding(3, 3, 3, 0);
+            filePathValueTextBox.MinimumSize = new Size(0, 34);
+            filePathValueTextBox.Name = "filePathValueTextBox";
+            filePathValueTextBox.ReadOnly = true;
+            filePathValueTextBox.ScrollBars = ScrollBars.Horizontal;
+            filePathValueTextBox.ShortcutsEnabled = true;
+            filePathValueTextBox.Size = new Size(834, 34);
+            filePathValueTextBox.TabIndex = 5;
+            filePathValueTextBox.TabStop = false;
+            filePathValueTextBox.Text = "Unsaved";
             //
             // editorSplitContainer
             //
             editorSplitContainer.Dock = DockStyle.Fill;
-            editorSplitContainer.Location = new Point(3, 183);
+            editorSplitContainer.Location = new Point(3, 195);
             editorSplitContainer.Name = "editorSplitContainer";
             //
             // editorSplitContainer.Panel1
@@ -289,8 +282,10 @@ namespace LotusECMLogger.Controls
             // editorSplitContainer.Panel2
             //
             editorSplitContainer.Panel2.Controls.Add(requestEditorLayout);
+            editorSplitContainer.FixedPanel = FixedPanel.Panel1;
             editorSplitContainer.Size = new Size(986, 457);
             editorSplitContainer.SplitterDistance = 255;
+            editorSplitContainer.SplitterWidth = 8;
             editorSplitContainer.TabIndex = 2;
             //
             // ecuGroupBox
@@ -371,7 +366,7 @@ namespace LotusECMLogger.Controls
             requestEditorLayout.Location = new Point(0, 0);
             requestEditorLayout.Name = "requestEditorLayout";
             requestEditorLayout.RowCount = 2;
-            requestEditorLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 110F));
+            requestEditorLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 148F));
             requestEditorLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
             requestEditorLayout.Size = new Size(727, 457);
             requestEditorLayout.TabIndex = 0;
@@ -382,7 +377,7 @@ namespace LotusECMLogger.Controls
             ecuDetailsGroupBox.Dock = DockStyle.Fill;
             ecuDetailsGroupBox.Location = new Point(3, 3);
             ecuDetailsGroupBox.Name = "ecuDetailsGroupBox";
-            ecuDetailsGroupBox.Size = new Size(721, 104);
+            ecuDetailsGroupBox.Size = new Size(721, 142);
             ecuDetailsGroupBox.TabIndex = 0;
             ecuDetailsGroupBox.TabStop = false;
             ecuDetailsGroupBox.Text = "Selected ECU";
@@ -402,17 +397,17 @@ namespace LotusECMLogger.Controls
             ecuDetailsLayout.Location = new Point(3, 27);
             ecuDetailsLayout.Name = "ecuDetailsLayout";
             ecuDetailsLayout.RowCount = 3;
-            ecuDetailsLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 33.3333321F));
-            ecuDetailsLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 33.3333321F));
-            ecuDetailsLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 33.3333321F));
-            ecuDetailsLayout.Size = new Size(715, 74);
+            ecuDetailsLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 36F));
+            ecuDetailsLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 36F));
+            ecuDetailsLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 36F));
+            ecuDetailsLayout.Size = new Size(715, 112);
             ecuDetailsLayout.TabIndex = 0;
             //
             // ecuNameLabel
             //
             ecuNameLabel.Anchor = AnchorStyles.Left;
             ecuNameLabel.AutoSize = true;
-            ecuNameLabel.Location = new Point(3, 0);
+            ecuNameLabel.Location = new Point(3, 5);
             ecuNameLabel.Name = "ecuNameLabel";
             ecuNameLabel.Size = new Size(91, 24);
             ecuNameLabel.TabIndex = 0;
@@ -422,8 +417,9 @@ namespace LotusECMLogger.Controls
             //
             ecuNameTextBox.Dock = DockStyle.Fill;
             ecuNameTextBox.Location = new Point(143, 3);
+            ecuNameTextBox.MinimumSize = new Size(0, 34);
             ecuNameTextBox.Name = "ecuNameTextBox";
-            ecuNameTextBox.Size = new Size(569, 31);
+            ecuNameTextBox.Size = new Size(569, 34);
             ecuNameTextBox.TabIndex = 1;
             ecuNameTextBox.TextChanged += EditorField_TextChanged;
             //
@@ -431,7 +427,7 @@ namespace LotusECMLogger.Controls
             //
             requestIdLabel.Anchor = AnchorStyles.Left;
             requestIdLabel.AutoSize = true;
-            requestIdLabel.Location = new Point(3, 24);
+            requestIdLabel.Location = new Point(3, 41);
             requestIdLabel.Name = "requestIdLabel";
             requestIdLabel.Size = new Size(128, 24);
             requestIdLabel.TabIndex = 2;
@@ -440,9 +436,10 @@ namespace LotusECMLogger.Controls
             // requestIdTextBox
             //
             requestIdTextBox.Dock = DockStyle.Fill;
-            requestIdTextBox.Location = new Point(143, 27);
+            requestIdTextBox.Location = new Point(143, 39);
+            requestIdTextBox.MinimumSize = new Size(0, 34);
             requestIdTextBox.Name = "requestIdTextBox";
-            requestIdTextBox.Size = new Size(569, 31);
+            requestIdTextBox.Size = new Size(569, 34);
             requestIdTextBox.TabIndex = 3;
             requestIdTextBox.TextChanged += EditorField_TextChanged;
             //
@@ -450,7 +447,7 @@ namespace LotusECMLogger.Controls
             //
             responseIdLabel.Anchor = AnchorStyles.Left;
             responseIdLabel.AutoSize = true;
-            responseIdLabel.Location = new Point(3, 49);
+            responseIdLabel.Location = new Point(3, 77);
             responseIdLabel.Name = "responseIdLabel";
             responseIdLabel.Size = new Size(137, 25);
             responseIdLabel.TabIndex = 4;
@@ -459,9 +456,10 @@ namespace LotusECMLogger.Controls
             // responseIdTextBox
             //
             responseIdTextBox.Dock = DockStyle.Fill;
-            responseIdTextBox.Location = new Point(143, 51);
+            responseIdTextBox.Location = new Point(143, 75);
+            responseIdTextBox.MinimumSize = new Size(0, 34);
             responseIdTextBox.Name = "responseIdTextBox";
-            responseIdTextBox.Size = new Size(569, 31);
+            responseIdTextBox.Size = new Size(569, 34);
             responseIdTextBox.TabIndex = 5;
             responseIdTextBox.TextChanged += EditorField_TextChanged;
             //
@@ -495,8 +493,7 @@ namespace LotusECMLogger.Controls
             //
             // requestButtonsPanel
             //
-            requestButtonsPanel.Controls.Add(addMode01Button);
-            requestButtonsPanel.Controls.Add(addMode22Button);
+            requestButtonsPanel.Controls.Add(addRequestButton);
             requestButtonsPanel.Controls.Add(removeRequestButton);
             requestButtonsPanel.Controls.Add(moveRequestUpButton);
             requestButtonsPanel.Controls.Add(moveRequestDownButton);
@@ -507,52 +504,62 @@ namespace LotusECMLogger.Controls
             requestButtonsPanel.TabIndex = 0;
             requestButtonsPanel.WrapContents = false;
             //
-            // addMode01Button
+            // addRequestButton
             //
-            addMode01Button.Location = new Point(3, 3);
-            addMode01Button.Name = "addMode01Button";
-            addMode01Button.Size = new Size(118, 30);
-            addMode01Button.TabIndex = 0;
-            addMode01Button.Text = "Add Mode01";
-            addMode01Button.UseVisualStyleBackColor = true;
-            addMode01Button.Click += AddMode01Button_Click;
-            //
-            // addMode22Button
-            //
-            addMode22Button.Location = new Point(127, 3);
-            addMode22Button.Name = "addMode22Button";
-            addMode22Button.Size = new Size(118, 30);
-            addMode22Button.TabIndex = 1;
-            addMode22Button.Text = "Add Mode22";
-            addMode22Button.UseVisualStyleBackColor = true;
-            addMode22Button.Click += AddMode22Button_Click;
+            addRequestButton.AutoSize = true;
+            addRequestButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            addRequestButton.Location = new Point(3, 3);
+            addRequestButton.Margin = new Padding(3, 3, 8, 3);
+            addRequestButton.MinimumSize = new Size(130, 30);
+            addRequestButton.Name = "addRequestButton";
+            addRequestButton.Padding = new Padding(10, 0, 10, 0);
+            addRequestButton.Size = new Size(130, 34);
+            addRequestButton.TabIndex = 0;
+            addRequestButton.Text = "Add Request";
+            addRequestButton.UseVisualStyleBackColor = true;
+            addRequestButton.Click += AddRequestButton_Click;
             //
             // removeRequestButton
             //
-            removeRequestButton.Location = new Point(251, 3);
+            removeRequestButton.AutoSize = true;
+            removeRequestButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            removeRequestButton.Location = new Point(141, 3);
+            removeRequestButton.Margin = new Padding(3, 3, 8, 3);
+            removeRequestButton.MinimumSize = new Size(138, 30);
             removeRequestButton.Name = "removeRequestButton";
-            removeRequestButton.Size = new Size(138, 30);
-            removeRequestButton.TabIndex = 2;
+            removeRequestButton.Padding = new Padding(10, 0, 10, 0);
+            removeRequestButton.Size = new Size(150, 34);
+            removeRequestButton.TabIndex = 1;
             removeRequestButton.Text = "Remove Request";
             removeRequestButton.UseVisualStyleBackColor = true;
             removeRequestButton.Click += RemoveRequestButton_Click;
             //
             // moveRequestUpButton
             //
-            moveRequestUpButton.Location = new Point(395, 3);
+            moveRequestUpButton.AutoSize = true;
+            moveRequestUpButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            moveRequestUpButton.Location = new Point(299, 3);
+            moveRequestUpButton.Margin = new Padding(3, 3, 8, 3);
+            moveRequestUpButton.MinimumSize = new Size(90, 30);
             moveRequestUpButton.Name = "moveRequestUpButton";
-            moveRequestUpButton.Size = new Size(89, 30);
-            moveRequestUpButton.TabIndex = 3;
+            moveRequestUpButton.Padding = new Padding(10, 0, 10, 0);
+            moveRequestUpButton.Size = new Size(104, 34);
+            moveRequestUpButton.TabIndex = 2;
             moveRequestUpButton.Text = "Move Up";
             moveRequestUpButton.UseVisualStyleBackColor = true;
             moveRequestUpButton.Click += MoveRequestUpButton_Click;
             //
             // moveRequestDownButton
             //
-            moveRequestDownButton.Location = new Point(490, 3);
+            moveRequestDownButton.AutoSize = true;
+            moveRequestDownButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            moveRequestDownButton.Location = new Point(411, 3);
+            moveRequestDownButton.Margin = new Padding(3, 3, 8, 3);
+            moveRequestDownButton.MinimumSize = new Size(110, 30);
             moveRequestDownButton.Name = "moveRequestDownButton";
-            moveRequestDownButton.Size = new Size(109, 30);
-            moveRequestDownButton.TabIndex = 4;
+            moveRequestDownButton.Padding = new Padding(10, 0, 10, 0);
+            moveRequestDownButton.Size = new Size(123, 34);
+            moveRequestDownButton.TabIndex = 3;
             moveRequestDownButton.Text = "Move Down";
             moveRequestDownButton.UseVisualStyleBackColor = true;
             moveRequestDownButton.Click += MoveRequestDownButton_Click;
@@ -561,13 +568,14 @@ namespace LotusECMLogger.Controls
             //
             requestsDataGridView.AllowUserToAddRows = false;
             requestsDataGridView.AllowUserToDeleteRows = false;
-            requestsDataGridView.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
-            requestsDataGridView.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            requestsDataGridView.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.None;
+            requestsDataGridView.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
             requestsDataGridView.Dock = DockStyle.Fill;
             requestsDataGridView.Location = new Point(3, 45);
             requestsDataGridView.MultiSelect = false;
             requestsDataGridView.Name = "requestsDataGridView";
-            requestsDataGridView.RowHeadersWidth = 62;
+            requestsDataGridView.RowHeadersVisible = false;
+            requestsDataGridView.RowHeadersWidth = 28;
             requestsDataGridView.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
             requestsDataGridView.Size = new Size(709, 227);
             requestsDataGridView.TabIndex = 1;
@@ -623,7 +631,6 @@ namespace LotusECMLogger.Controls
         private FlowLayoutPanel topButtonPanel;
         private Label configPickerLabel;
         private ComboBox configPickerComboBox;
-        private Button loadConfigButton;
         private Button refreshConfigsButton;
         private Button newConfigButton;
         private Button saveConfigButton;
@@ -636,7 +643,7 @@ namespace LotusECMLogger.Controls
         private Label configDescriptionLabel;
         private TextBox configDescriptionTextBox;
         private Label filePathLabel;
-        private Label filePathValueLabel;
+        private TextBox filePathValueTextBox;
         private SplitContainer editorSplitContainer;
         private GroupBox ecuGroupBox;
         private TableLayoutPanel ecuLayout;
@@ -656,8 +663,7 @@ namespace LotusECMLogger.Controls
         private GroupBox requestsGroupBox;
         private TableLayoutPanel requestsLayout;
         private FlowLayoutPanel requestButtonsPanel;
-        private Button addMode01Button;
-        private Button addMode22Button;
+        private Button addRequestButton;
         private Button removeRequestButton;
         private Button moveRequestUpButton;
         private Button moveRequestDownButton;

--- a/LotusECMLogger/Controls/LoggingConfigEditorControl.cs
+++ b/LotusECMLogger/Controls/LoggingConfigEditorControl.cs
@@ -1,0 +1,824 @@
+using System.ComponentModel;
+using System.Globalization;
+using LotusECMLogger.Services;
+
+namespace LotusECMLogger.Controls
+{
+    public partial class LoggingConfigEditorControl : UserControl
+    {
+        public event Action<string>? ConfigurationSaved;
+
+        private readonly BindingList<EditableRequestRow> requestRows = new();
+        private MultiECUConfigurationJson currentConfig = LoggingConfigFileService.CreateDefaultConfig();
+        private string? currentFilePath;
+        private int currentEcuIndex = -1;
+        private bool isDirty;
+        private bool suppressDirtyTracking;
+        private bool suppressSelectionEvents;
+
+        public LoggingConfigEditorControl()
+        {
+            InitializeComponent();
+            InitializeRequestGrid();
+            Dock = DockStyle.Fill;
+            LoadAvailableConfigurations();
+            LoadInitialConfiguration();
+        }
+
+        private void InitializeRequestGrid()
+        {
+            requestsDataGridView.AutoGenerateColumns = false;
+            requestsDataGridView.Columns.Clear();
+
+            var typeColumn = new DataGridViewComboBoxColumn
+            {
+                DataPropertyName = nameof(EditableRequestRow.Type),
+                HeaderText = "Type",
+                DisplayStyle = DataGridViewComboBoxDisplayStyle.DropDownButton,
+                DataSource = new[] { "Mode01", "Mode22" },
+                FillWeight = 70
+            };
+            requestsDataGridView.Columns.Add(typeColumn);
+            requestsDataGridView.Columns.Add(new DataGridViewTextBoxColumn
+            {
+                DataPropertyName = nameof(EditableRequestRow.Name),
+                HeaderText = "Name",
+                FillWeight = 160
+            });
+            requestsDataGridView.Columns.Add(new DataGridViewTextBoxColumn
+            {
+                DataPropertyName = nameof(EditableRequestRow.Description),
+                HeaderText = "Description",
+                FillWeight = 150
+            });
+            requestsDataGridView.Columns.Add(new DataGridViewTextBoxColumn
+            {
+                DataPropertyName = nameof(EditableRequestRow.Category),
+                HeaderText = "Category",
+                FillWeight = 100
+            });
+            requestsDataGridView.Columns.Add(new DataGridViewTextBoxColumn
+            {
+                DataPropertyName = nameof(EditableRequestRow.Unit),
+                HeaderText = "Unit",
+                FillWeight = 70
+            });
+            requestsDataGridView.Columns.Add(new DataGridViewTextBoxColumn
+            {
+                DataPropertyName = nameof(EditableRequestRow.PidsText),
+                HeaderText = "PIDs",
+                FillWeight = 110
+            });
+            requestsDataGridView.Columns.Add(new DataGridViewTextBoxColumn
+            {
+                DataPropertyName = nameof(EditableRequestRow.PidHighText),
+                HeaderText = "PID High",
+                FillWeight = 75
+            });
+            requestsDataGridView.Columns.Add(new DataGridViewTextBoxColumn
+            {
+                DataPropertyName = nameof(EditableRequestRow.PidLowText),
+                HeaderText = "PID Low",
+                FillWeight = 75
+            });
+
+            requestsDataGridView.DataSource = requestRows;
+        }
+
+        private void LoadInitialConfiguration()
+        {
+            if (configPickerComboBox.Items.Count > 0)
+            {
+                configPickerComboBox.SelectedIndex = 0;
+                LoadConfigurationByName(configPickerComboBox.SelectedItem?.ToString());
+                return;
+            }
+
+            BeginNewConfiguration();
+        }
+
+        private void LoadAvailableConfigurations(string? preferredConfigName = null)
+        {
+            suppressSelectionEvents = true;
+
+            var existingSelection = preferredConfigName ?? configPickerComboBox.SelectedItem?.ToString();
+            configPickerComboBox.Items.Clear();
+
+            foreach (var config in MultiECUConfigurationLoader.GetAvailableConfigurations())
+            {
+                configPickerComboBox.Items.Add(config);
+            }
+
+            if (configPickerComboBox.Items.Count > 0)
+            {
+                var preferredIndex = existingSelection == null
+                    ? 0
+                    : configPickerComboBox.Items.IndexOf(existingSelection);
+                configPickerComboBox.SelectedIndex = preferredIndex >= 0 ? preferredIndex : 0;
+            }
+
+            suppressSelectionEvents = false;
+        }
+
+        private void LoadConfigurationByName(string? configName)
+        {
+            if (string.IsNullOrWhiteSpace(configName))
+            {
+                return;
+            }
+
+            try
+            {
+                currentConfig = LoggingConfigFileService.LoadEditableConfigFromName(configName);
+                currentFilePath = LoggingConfigFileService.TryGetConfigPath(configName);
+                BindConfigurationToUi();
+                SetDirty(false);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Failed to load configuration '{configName}': {ex.Message}", "Load Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void BindConfigurationToUi()
+        {
+            suppressDirtyTracking = true;
+
+            configNameTextBox.Text = currentConfig.Name;
+            configDescriptionTextBox.Text = currentConfig.Description;
+            filePathValueLabel.Text = currentFilePath ?? "Unsaved";
+
+            RebuildEcuList();
+
+            suppressDirtyTracking = false;
+            UpdateTitleState();
+            UpdateButtonState();
+        }
+
+        private void RebuildEcuList(int preferredIndex = 0)
+        {
+            suppressSelectionEvents = true;
+            ecuListBox.Items.Clear();
+
+            foreach (var group in currentConfig.Ecus ?? Enumerable.Empty<ECUGroupJson>())
+            {
+                ecuListBox.Items.Add(FormatEcuListItem(group));
+            }
+
+            if (ecuListBox.Items.Count > 0)
+            {
+                ecuListBox.SelectedIndex = Math.Clamp(preferredIndex, 0, ecuListBox.Items.Count - 1);
+            }
+            else
+            {
+                currentEcuIndex = -1;
+                requestRows.Clear();
+                ecuNameTextBox.Clear();
+                requestIdTextBox.Clear();
+                responseIdTextBox.Clear();
+            }
+
+            suppressSelectionEvents = false;
+
+            if (ecuListBox.Items.Count > 0)
+            {
+                LoadEcuIntoEditor(ecuListBox.SelectedIndex);
+            }
+
+            UpdateButtonState();
+        }
+
+        private void LoadEcuIntoEditor(int index)
+        {
+            if (currentConfig.Ecus == null || index < 0 || index >= currentConfig.Ecus.Count)
+            {
+                currentEcuIndex = -1;
+                return;
+            }
+
+            currentEcuIndex = index;
+            var selectedGroup = currentConfig.Ecus[index];
+
+            suppressDirtyTracking = true;
+            ecuNameTextBox.Text = selectedGroup.Name;
+            requestIdTextBox.Text = FormatUInt(selectedGroup.RequestId);
+            responseIdTextBox.Text = FormatUInt(selectedGroup.ResponseId);
+
+            requestRows.RaiseListChangedEvents = false;
+            requestRows.Clear();
+            foreach (var request in selectedGroup.Requests)
+            {
+                requestRows.Add(EditableRequestRow.FromRequest(request));
+            }
+            requestRows.RaiseListChangedEvents = true;
+            requestRows.ResetBindings();
+            suppressDirtyTracking = false;
+
+            UpdateButtonState();
+        }
+
+        private void BeginNewConfiguration()
+        {
+            currentConfig = LoggingConfigFileService.CreateDefaultConfig();
+            currentFilePath = null;
+            BindConfigurationToUi();
+            SetDirty(false);
+        }
+
+        private bool ConfirmDiscardUnsavedChanges()
+        {
+            if (!isDirty)
+            {
+                return true;
+            }
+
+            var result = MessageBox.Show(
+                "You have unsaved logging config changes. Discard them?",
+                "Unsaved Changes",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Warning);
+
+            return result == DialogResult.Yes;
+        }
+
+        private void RefreshConfigsButton_Click(object? sender, EventArgs e)
+        {
+            LoadAvailableConfigurations();
+        }
+
+        private void LoadConfigButton_Click(object? sender, EventArgs e)
+        {
+            if (suppressSelectionEvents)
+            {
+                return;
+            }
+
+            if (!ConfirmDiscardUnsavedChanges())
+            {
+                return;
+            }
+
+            LoadConfigurationByName(configPickerComboBox.SelectedItem?.ToString());
+        }
+
+        private void NewConfigButton_Click(object? sender, EventArgs e)
+        {
+            if (!ConfirmDiscardUnsavedChanges())
+            {
+                return;
+            }
+
+            BeginNewConfiguration();
+        }
+
+        private void SaveConfigButton_Click(object? sender, EventArgs e)
+        {
+            SaveCurrentConfiguration(saveAs: false);
+        }
+
+        private void SaveAsConfigButton_Click(object? sender, EventArgs e)
+        {
+            SaveCurrentConfiguration(saveAs: true);
+        }
+
+        private void SaveCurrentConfiguration(bool saveAs)
+        {
+            requestsDataGridView.EndEdit();
+
+            if (!PersistSelectedEcuEdits(out var validationError))
+            {
+                MessageBox.Show(validationError, "Validation Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            currentConfig.Name = configNameTextBox.Text.Trim();
+            currentConfig.Description = configDescriptionTextBox.Text.Trim();
+
+            if (string.IsNullOrWhiteSpace(currentConfig.Name))
+            {
+                MessageBox.Show("Please enter a configuration name before saving.", "Validation Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            string? filePath = currentFilePath;
+            if (saveAs || string.IsNullOrWhiteSpace(filePath))
+            {
+                filePath = PromptForSavePath();
+                if (string.IsNullOrWhiteSpace(filePath))
+                {
+                    return;
+                }
+            }
+
+            try
+            {
+                LoggingConfigFileService.SaveEditableConfig(currentConfig, filePath);
+                currentFilePath = filePath;
+
+                var savedConfigName = Path.GetFileNameWithoutExtension(filePath);
+                LoadAvailableConfigurations(savedConfigName);
+                filePathValueLabel.Text = filePath;
+                SetDirty(false);
+                ConfigurationSaved?.Invoke(savedConfigName);
+
+                MessageBox.Show($"Saved logging configuration to:\n{filePath}", "Configuration Saved", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Failed to save configuration: {ex.Message}", "Save Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private string? PromptForSavePath()
+        {
+            using var dialog = new SaveFileDialog
+            {
+                Filter = "JSON files (*.json)|*.json",
+                DefaultExt = "json",
+                AddExtension = true,
+                InitialDirectory = LoggingConfigFileService.GetPreferredConfigDirectory(),
+                FileName = BuildSuggestedFileName()
+            };
+
+            if (dialog.ShowDialog(this) != DialogResult.OK)
+            {
+                return null;
+            }
+
+            var selectedPath = Path.GetFullPath(dialog.FileName);
+            var configDirectory = Path.GetFullPath(LoggingConfigFileService.GetPreferredConfigDirectory());
+            var selectedDirectory = Path.GetDirectoryName(selectedPath);
+            var isInsideConfigDirectory = !string.IsNullOrWhiteSpace(selectedDirectory)
+                && (string.Equals(Path.GetFullPath(selectedDirectory), configDirectory, StringComparison.OrdinalIgnoreCase)
+                    || Path.GetFullPath(selectedDirectory).StartsWith($"{configDirectory}{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase));
+
+            if (!isInsideConfigDirectory)
+            {
+                MessageBox.Show(
+                    $"Please save logging configs inside:\n{configDirectory}",
+                    "Save Location Required",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+                return null;
+            }
+
+            return selectedPath;
+        }
+
+        private string BuildSuggestedFileName()
+        {
+            var nameSource = string.IsNullOrWhiteSpace(configNameTextBox.Text)
+                ? "custom-logging-config"
+                : configNameTextBox.Text.Trim().ToLowerInvariant();
+
+            var invalidChars = Path.GetInvalidFileNameChars();
+            var sanitized = new string(nameSource
+                .Select(ch => invalidChars.Contains(ch) ? '-' : ch)
+                .ToArray());
+
+            sanitized = string.Join("-", sanitized
+                .Split([' ', '_', '-'], StringSplitOptions.RemoveEmptyEntries));
+
+            return string.IsNullOrWhiteSpace(sanitized) ? "custom-logging-config.json" : $"{sanitized}.json";
+        }
+
+        private void EditorField_TextChanged(object? sender, EventArgs e)
+        {
+            SetDirty();
+        }
+
+        private void AddEcuButton_Click(object? sender, EventArgs e)
+        {
+            if (!PersistSelectedEcuEdits(out var error))
+            {
+                MessageBox.Show(error, "Validation Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            currentConfig.Ecus ??= new List<ECUGroupJson>();
+            currentConfig.Ecus.Add(new ECUGroupJson
+            {
+                Name = $"ECU {currentConfig.Ecus.Count + 1}",
+                RequestId = ECUDefinition.ECM.RequestId,
+                ResponseId = ECUDefinition.ECM.ResponseId,
+                Requests = new List<OBDRequestJson>()
+            });
+
+            RebuildEcuList(currentConfig.Ecus.Count - 1);
+            SetDirty();
+        }
+
+        private void RemoveEcuButton_Click(object? sender, EventArgs e)
+        {
+            if (currentConfig.Ecus == null || currentEcuIndex < 0 || currentEcuIndex >= currentConfig.Ecus.Count)
+            {
+                return;
+            }
+
+            if (currentConfig.Ecus.Count == 1)
+            {
+                MessageBox.Show("A logging configuration needs at least one ECU.", "Cannot Remove", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            currentConfig.Ecus.RemoveAt(currentEcuIndex);
+            RebuildEcuList(Math.Max(0, currentEcuIndex - 1));
+            SetDirty();
+        }
+
+        private void EcuListBox_SelectedIndexChanged(object? sender, EventArgs e)
+        {
+            if (suppressSelectionEvents)
+            {
+                return;
+            }
+
+            var requestedIndex = ecuListBox.SelectedIndex;
+            if (requestedIndex == currentEcuIndex)
+            {
+                return;
+            }
+
+            if (!PersistSelectedEcuEdits(out var error))
+            {
+                suppressSelectionEvents = true;
+                ecuListBox.SelectedIndex = currentEcuIndex;
+                suppressSelectionEvents = false;
+                MessageBox.Show(error, "Validation Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            if (requestedIndex >= 0)
+            {
+                LoadEcuIntoEditor(requestedIndex);
+            }
+        }
+
+        private bool PersistSelectedEcuEdits(out string errorMessage)
+        {
+            errorMessage = string.Empty;
+
+            if (currentConfig.Ecus == null || currentEcuIndex < 0 || currentEcuIndex >= currentConfig.Ecus.Count)
+            {
+                return true;
+            }
+
+            if (string.IsNullOrWhiteSpace(ecuNameTextBox.Text))
+            {
+                errorMessage = "ECU name cannot be empty.";
+                return false;
+            }
+
+            if (!TryParseUIntValue(requestIdTextBox.Text, out var requestId))
+            {
+                errorMessage = "Request ID must be a valid decimal or hex value like 0x7E0.";
+                return false;
+            }
+
+            if (!TryParseUIntValue(responseIdTextBox.Text, out var responseId))
+            {
+                errorMessage = "Response ID must be a valid decimal or hex value like 0x7E8.";
+                return false;
+            }
+
+            var convertedRequests = new List<OBDRequestJson>();
+            for (int i = 0; i < requestRows.Count; i++)
+            {
+                var row = requestRows[i];
+                if (!TryConvertRowToRequest(row, out var request, out errorMessage))
+                {
+                    errorMessage = $"Request {i + 1}: {errorMessage}";
+                    return false;
+                }
+
+                convertedRequests.Add(request);
+            }
+
+            convertedRequests = OrderRequestsWithMode22First(convertedRequests);
+
+            var targetGroup = currentConfig.Ecus[currentEcuIndex];
+            targetGroup.Name = ecuNameTextBox.Text.Trim();
+            targetGroup.RequestId = requestId;
+            targetGroup.ResponseId = responseId;
+            targetGroup.Requests = convertedRequests;
+
+            suppressSelectionEvents = true;
+            ecuListBox.Items[currentEcuIndex] = FormatEcuListItem(targetGroup);
+            suppressSelectionEvents = false;
+            ReloadOrderedRequestsIntoGrid(convertedRequests);
+            return true;
+        }
+
+        private bool TryConvertRowToRequest(EditableRequestRow row, out OBDRequestJson request, out string errorMessage)
+        {
+            request = new OBDRequestJson();
+            errorMessage = string.Empty;
+
+            var normalizedType = row.Type?.Trim();
+            if (!string.Equals(normalizedType, "Mode01", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(normalizedType, "Mode22", StringComparison.OrdinalIgnoreCase))
+            {
+                errorMessage = "Type must be Mode01 or Mode22.";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(row.Name))
+            {
+                errorMessage = "Request name cannot be empty.";
+                return false;
+            }
+
+            request.Type = normalizedType;
+            request.Name = row.Name.Trim();
+            request.Description = row.Description?.Trim() ?? string.Empty;
+            request.Category = row.Category?.Trim() ?? string.Empty;
+            request.Unit = row.Unit?.Trim() ?? string.Empty;
+
+            if (string.Equals(normalizedType, "Mode01", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!TryParseByteList(row.PidsText, out var pids))
+                {
+                    errorMessage = "Mode01 requests need one or more PIDs separated by commas.";
+                    return false;
+                }
+
+                request.Pids = pids;
+                request.PidHigh = null;
+                request.PidLow = null;
+                return true;
+            }
+
+            if (!TryParseByteValue(row.PidHighText, out var pidHigh))
+            {
+                errorMessage = "PID High must be a valid byte value.";
+                return false;
+            }
+
+            if (!TryParseByteValue(row.PidLowText, out var pidLow))
+            {
+                errorMessage = "PID Low must be a valid byte value.";
+                return false;
+            }
+
+            request.Pids = null;
+            request.PidHigh = pidHigh;
+            request.PidLow = pidLow;
+            return true;
+        }
+
+        private void AddMode01Button_Click(object? sender, EventArgs e)
+        {
+            requestRows.Add(new EditableRequestRow
+            {
+                Type = "Mode01",
+                Name = "New Mode01 Request",
+                PidsText = "0x0C"
+            });
+            SetDirty();
+        }
+
+        private void AddMode22Button_Click(object? sender, EventArgs e)
+        {
+            requestRows.Add(new EditableRequestRow
+            {
+                Type = "Mode22",
+                Name = "New Mode22 Request",
+                PidHighText = "0x00",
+                PidLowText = "0x00"
+            });
+            SetDirty();
+        }
+
+        private void RemoveRequestButton_Click(object? sender, EventArgs e)
+        {
+            if (requestsDataGridView.CurrentRow?.DataBoundItem is not EditableRequestRow requestRow)
+            {
+                return;
+            }
+
+            requestRows.Remove(requestRow);
+            SetDirty();
+        }
+
+        private void MoveRequestUpButton_Click(object? sender, EventArgs e)
+        {
+            MoveSelectedRequest(-1);
+        }
+
+        private void MoveRequestDownButton_Click(object? sender, EventArgs e)
+        {
+            MoveSelectedRequest(1);
+        }
+
+        private void MoveSelectedRequest(int direction)
+        {
+            if (requestsDataGridView.CurrentRow?.DataBoundItem is not EditableRequestRow requestRow)
+            {
+                return;
+            }
+
+            var currentIndex = requestRows.IndexOf(requestRow);
+            if (currentIndex < 0)
+            {
+                return;
+            }
+
+            var newIndex = currentIndex + direction;
+            if (newIndex < 0 || newIndex >= requestRows.Count)
+            {
+                return;
+            }
+
+            requestRows.RemoveAt(currentIndex);
+            requestRows.Insert(newIndex, requestRow);
+            requestsDataGridView.ClearSelection();
+            requestsDataGridView.Rows[newIndex].Selected = true;
+            SetDirty();
+        }
+
+        private void RequestsDataGridView_CurrentCellDirtyStateChanged(object? sender, EventArgs e)
+        {
+            if (requestsDataGridView.IsCurrentCellDirty)
+            {
+                requestsDataGridView.CommitEdit(DataGridViewDataErrorContexts.Commit);
+            }
+        }
+
+        private void RequestsDataGridView_CellValueChanged(object? sender, DataGridViewCellEventArgs e)
+        {
+            if (e.RowIndex >= 0)
+            {
+                SetDirty();
+            }
+        }
+
+        private void RequestsDataGridView_UserDeletingRow(object? sender, DataGridViewRowCancelEventArgs e)
+        {
+            SetDirty();
+        }
+
+        private void SetDirty(bool dirty = true)
+        {
+            if (suppressDirtyTracking)
+            {
+                return;
+            }
+
+            isDirty = dirty;
+            UpdateTitleState();
+            UpdateButtonState();
+        }
+
+        private void UpdateTitleState()
+        {
+            metadataGroupBox.Text = isDirty ? "Configuration Details *" : "Configuration Details";
+        }
+
+        private void UpdateButtonState()
+        {
+            var hasEcuSelection = currentEcuIndex >= 0;
+            removeEcuButton.Enabled = (currentConfig.Ecus?.Count ?? 0) > 1;
+            addMode01Button.Enabled = hasEcuSelection;
+            addMode22Button.Enabled = hasEcuSelection;
+            removeRequestButton.Enabled = hasEcuSelection && requestRows.Count > 0;
+            moveRequestUpButton.Enabled = hasEcuSelection && requestRows.Count > 1;
+            moveRequestDownButton.Enabled = hasEcuSelection && requestRows.Count > 1;
+            saveConfigButton.Enabled = (currentConfig.Ecus?.Count ?? 0) > 0;
+            saveAsConfigButton.Enabled = saveConfigButton.Enabled;
+        }
+
+        private static string FormatEcuListItem(ECUGroupJson group)
+        {
+            return $"{group.Name} [{FormatUInt(group.RequestId)}]";
+        }
+
+        private void ReloadOrderedRequestsIntoGrid(IReadOnlyCollection<OBDRequestJson> orderedRequests)
+        {
+            suppressDirtyTracking = true;
+            requestRows.RaiseListChangedEvents = false;
+            requestRows.Clear();
+            foreach (var request in orderedRequests)
+            {
+                requestRows.Add(EditableRequestRow.FromRequest(request));
+            }
+            requestRows.RaiseListChangedEvents = true;
+            requestRows.ResetBindings();
+            suppressDirtyTracking = false;
+            UpdateButtonState();
+        }
+
+        private static List<OBDRequestJson> OrderRequestsWithMode22First(IEnumerable<OBDRequestJson> requests)
+        {
+            return requests
+                .Select((request, index) => new { request, index })
+                .OrderBy(item => IsMode22(item.request) ? 0 : 1)
+                .ThenBy(item => item.index)
+                .Select(item => item.request)
+                .ToList();
+        }
+
+        private static bool IsMode22(OBDRequestJson request)
+        {
+            return string.Equals(request.Type, "Mode22", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string FormatUInt(uint value)
+        {
+            return $"0x{value:X}";
+        }
+
+        private static string FormatByte(byte value)
+        {
+            return $"0x{value:X2}";
+        }
+
+        private static bool TryParseUIntValue(string? text, out uint value)
+        {
+            value = 0;
+
+            var normalized = text?.Trim();
+            if (string.IsNullOrWhiteSpace(normalized))
+            {
+                return false;
+            }
+
+            if (normalized.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            {
+                return uint.TryParse(normalized[2..], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out value);
+            }
+
+            if (uint.TryParse(normalized, NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
+            {
+                return true;
+            }
+
+            return uint.TryParse(normalized, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out value);
+        }
+
+        private static bool TryParseByteValue(string? text, out byte value)
+        {
+            value = 0;
+
+            if (!TryParseUIntValue(text, out var parsedValue) || parsedValue > byte.MaxValue)
+            {
+                return false;
+            }
+
+            value = (byte)parsedValue;
+            return true;
+        }
+
+        private static bool TryParseByteList(string? text, out byte[] values)
+        {
+            values = Array.Empty<byte>();
+            var tokens = (text ?? string.Empty)
+                .Split([',', ';', ' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+
+            if (tokens.Length == 0)
+            {
+                return false;
+            }
+
+            var parsedValues = new List<byte>();
+            foreach (var token in tokens)
+            {
+                if (!TryParseByteValue(token, out var value))
+                {
+                    return false;
+                }
+
+                parsedValues.Add(value);
+            }
+
+            values = parsedValues.ToArray();
+            return true;
+        }
+
+        private sealed class EditableRequestRow
+        {
+            public string Type { get; set; } = "Mode22";
+            public string Name { get; set; } = string.Empty;
+            public string Description { get; set; } = string.Empty;
+            public string Category { get; set; } = string.Empty;
+            public string Unit { get; set; } = string.Empty;
+            public string PidsText { get; set; } = string.Empty;
+            public string PidHighText { get; set; } = string.Empty;
+            public string PidLowText { get; set; } = string.Empty;
+
+            public static EditableRequestRow FromRequest(OBDRequestJson request)
+            {
+                return new EditableRequestRow
+                {
+                    Type = string.IsNullOrWhiteSpace(request.Type) ? "Mode22" : request.Type,
+                    Name = request.Name,
+                    Description = request.Description,
+                    Category = request.Category,
+                    Unit = request.Unit,
+                    PidsText = request.Pids == null ? string.Empty : string.Join(", ", request.Pids.Select(FormatByte)),
+                    PidHighText = request.PidHigh.HasValue ? FormatByte(request.PidHigh.Value) : string.Empty,
+                    PidLowText = request.PidLow.HasValue ? FormatByte(request.PidLow.Value) : string.Empty
+                };
+            }
+        }
+    }
+}

--- a/LotusECMLogger/Controls/LoggingConfigEditorControl.cs
+++ b/LotusECMLogger/Controls/LoggingConfigEditorControl.cs
@@ -11,24 +11,149 @@ namespace LotusECMLogger.Controls
         private readonly BindingList<EditableRequestRow> requestRows = new();
         private MultiECUConfigurationJson currentConfig = LoggingConfigFileService.CreateDefaultConfig();
         private string? currentFilePath;
+        private string? currentLoadedConfigName;
         private int currentEcuIndex = -1;
         private bool isDirty;
         private bool suppressDirtyTracking;
         private bool suppressSelectionEvents;
+        private Form? hostForm;
+        private bool isResizeOptimizationActive;
+        private bool requestHelpWasVisible;
+        private bool requestsGridWasVisible;
 
         public LoggingConfigEditorControl()
         {
             InitializeComponent();
+            SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.OptimizedDoubleBuffer | ControlStyles.UserPaint, true);
+            UpdateStyles();
+            ConfigureLayoutBehavior();
             InitializeRequestGrid();
             Dock = DockStyle.Fill;
             LoadAvailableConfigurations();
             LoadInitialConfiguration();
         }
 
+        private void ConfigureLayoutBehavior()
+        {
+            editorSplitContainer.Panel1MinSize = 220;
+            editorSplitContainer.Panel2MinSize = 420;
+
+            EnableDoubleBuffering(requestsDataGridView);
+            EnableDoubleBuffering(editorLayout);
+            EnableDoubleBuffering(metadataLayout);
+            EnableDoubleBuffering(requestEditorLayout);
+            EnableDoubleBuffering(editorSplitContainer);
+        }
+
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            AttachHostFormHandlers();
+        }
+
+        protected override void OnParentChanged(EventArgs e)
+        {
+            base.OnParentChanged(e);
+            AttachHostFormHandlers();
+        }
+
+        protected override void OnHandleDestroyed(EventArgs e)
+        {
+            DetachHostFormHandlers();
+            base.OnHandleDestroyed(e);
+        }
+
+        private void AttachHostFormHandlers()
+        {
+            var form = FindForm();
+            if (ReferenceEquals(hostForm, form))
+            {
+                return;
+            }
+
+            DetachHostFormHandlers();
+            hostForm = form;
+
+            if (hostForm != null)
+            {
+                hostForm.ResizeBegin += HostForm_ResizeBegin;
+                hostForm.ResizeEnd += HostForm_ResizeEnd;
+            }
+        }
+
+        private void DetachHostFormHandlers()
+        {
+            if (hostForm == null)
+            {
+                return;
+            }
+
+            hostForm.ResizeBegin -= HostForm_ResizeBegin;
+            hostForm.ResizeEnd -= HostForm_ResizeEnd;
+            hostForm = null;
+        }
+
+        private void HostForm_ResizeBegin(object? sender, EventArgs e)
+        {
+            if (!Visible || isResizeOptimizationActive)
+            {
+                return;
+            }
+
+            isResizeOptimizationActive = true;
+            requestsGridWasVisible = requestsDataGridView.Visible;
+            requestHelpWasVisible = requestHelpLabel.Visible;
+
+            SuspendHeavyLayout();
+            requestsDataGridView.Visible = false;
+            requestHelpLabel.Visible = false;
+        }
+
+        private void HostForm_ResizeEnd(object? sender, EventArgs e)
+        {
+            if (!isResizeOptimizationActive)
+            {
+                return;
+            }
+
+            requestsDataGridView.Visible = requestsGridWasVisible;
+            requestHelpLabel.Visible = requestHelpWasVisible;
+            ResumeHeavyLayout();
+            isResizeOptimizationActive = false;
+        }
+
+        private void SuspendHeavyLayout()
+        {
+            SuspendLayout();
+            editorLayout.SuspendLayout();
+            metadataLayout.SuspendLayout();
+            editorSplitContainer.SuspendLayout();
+            requestEditorLayout.SuspendLayout();
+            ecuDetailsLayout.SuspendLayout();
+            requestsGroupBox.SuspendLayout();
+        }
+
+        private void ResumeHeavyLayout()
+        {
+            requestsGroupBox.ResumeLayout(true);
+            ecuDetailsLayout.ResumeLayout(true);
+            requestEditorLayout.ResumeLayout(true);
+            editorSplitContainer.ResumeLayout(true);
+            metadataLayout.ResumeLayout(true);
+            editorLayout.ResumeLayout(true);
+            ResumeLayout(true);
+            Invalidate(true);
+            Update();
+        }
+
         private void InitializeRequestGrid()
         {
             requestsDataGridView.AutoGenerateColumns = false;
             requestsDataGridView.Columns.Clear();
+            requestsDataGridView.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.None;
+            requestsDataGridView.RowHeadersWidthSizeMode = DataGridViewRowHeadersWidthSizeMode.DisableResizing;
+            requestsDataGridView.AllowUserToResizeRows = false;
+            requestsDataGridView.AllowUserToOrderColumns = false;
 
             var typeColumn = new DataGridViewComboBoxColumn
             {
@@ -36,50 +161,58 @@ namespace LotusECMLogger.Controls
                 HeaderText = "Type",
                 DisplayStyle = DataGridViewComboBoxDisplayStyle.DropDownButton,
                 DataSource = new[] { "Mode01", "Mode22" },
-                FillWeight = 70
+                Width = 110,
+                MinimumWidth = 100
             };
             requestsDataGridView.Columns.Add(typeColumn);
             requestsDataGridView.Columns.Add(new DataGridViewTextBoxColumn
             {
                 DataPropertyName = nameof(EditableRequestRow.Name),
                 HeaderText = "Name",
-                FillWeight = 160
+                Width = 170,
+                MinimumWidth = 140
             });
             requestsDataGridView.Columns.Add(new DataGridViewTextBoxColumn
             {
                 DataPropertyName = nameof(EditableRequestRow.Description),
                 HeaderText = "Description",
-                FillWeight = 150
+                Width = 300,
+                MinimumWidth = 220
             });
             requestsDataGridView.Columns.Add(new DataGridViewTextBoxColumn
             {
                 DataPropertyName = nameof(EditableRequestRow.Category),
                 HeaderText = "Category",
-                FillWeight = 100
+                Width = 170,
+                MinimumWidth = 130
             });
             requestsDataGridView.Columns.Add(new DataGridViewTextBoxColumn
             {
                 DataPropertyName = nameof(EditableRequestRow.Unit),
                 HeaderText = "Unit",
-                FillWeight = 70
+                Width = 80,
+                MinimumWidth = 70
             });
             requestsDataGridView.Columns.Add(new DataGridViewTextBoxColumn
             {
                 DataPropertyName = nameof(EditableRequestRow.PidsText),
                 HeaderText = "PIDs",
-                FillWeight = 110
+                Width = 180,
+                MinimumWidth = 140
             });
             requestsDataGridView.Columns.Add(new DataGridViewTextBoxColumn
             {
                 DataPropertyName = nameof(EditableRequestRow.PidHighText),
                 HeaderText = "PID High",
-                FillWeight = 75
+                Width = 90,
+                MinimumWidth = 80
             });
             requestsDataGridView.Columns.Add(new DataGridViewTextBoxColumn
             {
                 DataPropertyName = nameof(EditableRequestRow.PidLowText),
                 HeaderText = "PID Low",
-                FillWeight = 75
+                Width = 90,
+                MinimumWidth = 80
             });
 
             requestsDataGridView.DataSource = requestRows;
@@ -89,8 +222,7 @@ namespace LotusECMLogger.Controls
         {
             if (configPickerComboBox.Items.Count > 0)
             {
-                configPickerComboBox.SelectedIndex = 0;
-                LoadConfigurationByName(configPickerComboBox.SelectedItem?.ToString());
+                LoadConfigurationByName(configPickerComboBox.Items[0]?.ToString());
                 return;
             }
 
@@ -131,6 +263,8 @@ namespace LotusECMLogger.Controls
             {
                 currentConfig = LoggingConfigFileService.LoadEditableConfigFromName(configName);
                 currentFilePath = LoggingConfigFileService.TryGetConfigPath(configName);
+                currentLoadedConfigName = configName;
+                UpdateConfigPickerSelection(configName);
                 BindConfigurationToUi();
                 SetDirty(false);
             }
@@ -146,7 +280,7 @@ namespace LotusECMLogger.Controls
 
             configNameTextBox.Text = currentConfig.Name;
             configDescriptionTextBox.Text = currentConfig.Description;
-            filePathValueLabel.Text = currentFilePath ?? "Unsaved";
+            filePathValueTextBox.Text = currentFilePath ?? "Unsaved";
 
             RebuildEcuList();
 
@@ -221,6 +355,8 @@ namespace LotusECMLogger.Controls
         {
             currentConfig = LoggingConfigFileService.CreateDefaultConfig();
             currentFilePath = null;
+            currentLoadedConfigName = null;
+            UpdateConfigPickerSelection(null);
             BindConfigurationToUi();
             SetDirty(false);
         }
@@ -243,22 +379,29 @@ namespace LotusECMLogger.Controls
 
         private void RefreshConfigsButton_Click(object? sender, EventArgs e)
         {
-            LoadAvailableConfigurations();
+            LoadAvailableConfigurations(currentLoadedConfigName);
         }
 
-        private void LoadConfigButton_Click(object? sender, EventArgs e)
+        private void ConfigPickerComboBox_SelectedIndexChanged(object? sender, EventArgs e)
         {
             if (suppressSelectionEvents)
             {
                 return;
             }
 
-            if (!ConfirmDiscardUnsavedChanges())
+            var selectedConfigName = configPickerComboBox.SelectedItem?.ToString();
+            if (string.IsNullOrWhiteSpace(selectedConfigName) || string.Equals(selectedConfigName, currentLoadedConfigName, StringComparison.Ordinal))
             {
                 return;
             }
 
-            LoadConfigurationByName(configPickerComboBox.SelectedItem?.ToString());
+            if (!ConfirmDiscardUnsavedChanges())
+            {
+                UpdateConfigPickerSelection(currentLoadedConfigName);
+                return;
+            }
+
+            LoadConfigurationByName(selectedConfigName);
         }
 
         private void NewConfigButton_Click(object? sender, EventArgs e)
@@ -316,8 +459,9 @@ namespace LotusECMLogger.Controls
                 currentFilePath = filePath;
 
                 var savedConfigName = Path.GetFileNameWithoutExtension(filePath);
+                currentLoadedConfigName = savedConfigName;
                 LoadAvailableConfigurations(savedConfigName);
-                filePathValueLabel.Text = filePath;
+                filePathValueTextBox.Text = filePath;
                 SetDirty(false);
                 ConfigurationSaved?.Invoke(savedConfigName);
 
@@ -494,8 +638,6 @@ namespace LotusECMLogger.Controls
                 convertedRequests.Add(request);
             }
 
-            convertedRequests = OrderRequestsWithMode22First(convertedRequests);
-
             var targetGroup = currentConfig.Ecus[currentEcuIndex];
             targetGroup.Name = ecuNameTextBox.Text.Trim();
             targetGroup.RequestId = requestId;
@@ -566,26 +708,28 @@ namespace LotusECMLogger.Controls
             return true;
         }
 
-        private void AddMode01Button_Click(object? sender, EventArgs e)
+        private void AddRequestButton_Click(object? sender, EventArgs e)
         {
-            requestRows.Add(new EditableRequestRow
+            using var dialog = new AddRequestDialog();
+            if (dialog.ShowDialog(this) != DialogResult.OK)
             {
-                Type = "Mode01",
-                Name = "New Mode01 Request",
-                PidsText = "0x0C"
-            });
-            SetDirty();
-        }
+                return;
+            }
 
-        private void AddMode22Button_Click(object? sender, EventArgs e)
-        {
-            requestRows.Add(new EditableRequestRow
+            requestRows.Add(dialog.BuildRow());
+
+            var lastRowIndex = requestRows.Count - 1;
+            if (lastRowIndex >= 0 && lastRowIndex < requestsDataGridView.Rows.Count)
             {
-                Type = "Mode22",
-                Name = "New Mode22 Request",
-                PidHighText = "0x00",
-                PidLowText = "0x00"
-            });
+                requestsDataGridView.ClearSelection();
+                var gridRow = requestsDataGridView.Rows[lastRowIndex];
+                gridRow.Selected = true;
+                if (gridRow.Cells.Count > 0)
+                {
+                    requestsDataGridView.CurrentCell = gridRow.Cells[Math.Min(1, gridRow.Cells.Count - 1)];
+                }
+            }
+
             SetDirty();
         }
 
@@ -632,7 +776,12 @@ namespace LotusECMLogger.Controls
             requestRows.RemoveAt(currentIndex);
             requestRows.Insert(newIndex, requestRow);
             requestsDataGridView.ClearSelection();
-            requestsDataGridView.Rows[newIndex].Selected = true;
+            var targetRow = requestsDataGridView.Rows[newIndex];
+            targetRow.Selected = true;
+            if (targetRow.Cells.Count > 0)
+            {
+                requestsDataGridView.CurrentCell = targetRow.Cells[Math.Min(1, targetRow.Cells.Count - 1)];
+            }
             SetDirty();
         }
 
@@ -678,8 +827,7 @@ namespace LotusECMLogger.Controls
         {
             var hasEcuSelection = currentEcuIndex >= 0;
             removeEcuButton.Enabled = (currentConfig.Ecus?.Count ?? 0) > 1;
-            addMode01Button.Enabled = hasEcuSelection;
-            addMode22Button.Enabled = hasEcuSelection;
+            addRequestButton.Enabled = hasEcuSelection;
             removeRequestButton.Enabled = hasEcuSelection && requestRows.Count > 0;
             moveRequestUpButton.Enabled = hasEcuSelection && requestRows.Count > 1;
             moveRequestDownButton.Enabled = hasEcuSelection && requestRows.Count > 1;
@@ -705,21 +853,6 @@ namespace LotusECMLogger.Controls
             requestRows.ResetBindings();
             suppressDirtyTracking = false;
             UpdateButtonState();
-        }
-
-        private static List<OBDRequestJson> OrderRequestsWithMode22First(IEnumerable<OBDRequestJson> requests)
-        {
-            return requests
-                .Select((request, index) => new { request, index })
-                .OrderBy(item => IsMode22(item.request) ? 0 : 1)
-                .ThenBy(item => item.index)
-                .Select(item => item.request)
-                .ToList();
-        }
-
-        private static bool IsMode22(OBDRequestJson request)
-        {
-            return string.Equals(request.Type, "Mode22", StringComparison.OrdinalIgnoreCase);
         }
 
         private static string FormatUInt(uint value)
@@ -792,6 +925,210 @@ namespace LotusECMLogger.Controls
 
             values = parsedValues.ToArray();
             return true;
+        }
+
+        private void UpdateConfigPickerSelection(string? configName)
+        {
+            suppressSelectionEvents = true;
+            configPickerComboBox.SelectedIndex = string.IsNullOrWhiteSpace(configName)
+                ? -1
+                : configPickerComboBox.Items.IndexOf(configName);
+            suppressSelectionEvents = false;
+        }
+
+        private static void EnableDoubleBuffering(Control control)
+        {
+            typeof(Control)
+                .GetProperty("DoubleBuffered", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                ?.SetValue(control, true, null);
+        }
+
+        private sealed class AddRequestDialog : Form
+        {
+            private readonly ComboBox typeComboBox;
+            private readonly TextBox nameTextBox;
+            private readonly TextBox descriptionTextBox;
+            private readonly TextBox categoryTextBox;
+            private readonly TextBox unitTextBox;
+            private readonly TextBox pidsTextBox;
+            private readonly TextBox pidHighTextBox;
+            private readonly TextBox pidLowTextBox;
+            private readonly Label pidsLabel;
+            private readonly Label pidHighLabel;
+            private readonly Label pidLowLabel;
+
+            public AddRequestDialog()
+            {
+                Text = "Add Request";
+                FormBorderStyle = FormBorderStyle.FixedDialog;
+                StartPosition = FormStartPosition.CenterParent;
+                MaximizeBox = false;
+                MinimizeBox = false;
+                ShowInTaskbar = false;
+                ClientSize = new Size(700, 470);
+                MinimumSize = new Size(700, 470);
+                AutoScaleMode = AutoScaleMode.Font;
+
+                var layout = new TableLayoutPanel
+                {
+                    AutoScroll = true,
+                    Dock = DockStyle.Fill,
+                    ColumnCount = 2,
+                    RowCount = 9,
+                    Padding = new Padding(12)
+                };
+                layout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 145F));
+                layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+                layout.RowStyles.Add(new RowStyle(SizeType.Absolute, 40F));
+                layout.RowStyles.Add(new RowStyle(SizeType.Absolute, 40F));
+                layout.RowStyles.Add(new RowStyle(SizeType.Absolute, 96F));
+                layout.RowStyles.Add(new RowStyle(SizeType.Absolute, 40F));
+                layout.RowStyles.Add(new RowStyle(SizeType.Absolute, 40F));
+                layout.RowStyles.Add(new RowStyle(SizeType.Absolute, 40F));
+                layout.RowStyles.Add(new RowStyle(SizeType.Absolute, 40F));
+                layout.RowStyles.Add(new RowStyle(SizeType.Absolute, 40F));
+                layout.RowStyles.Add(new RowStyle(SizeType.Absolute, 56F));
+
+                typeComboBox = new ComboBox { Dock = DockStyle.Fill, DropDownStyle = ComboBoxStyle.DropDownList };
+                typeComboBox.Items.AddRange(["Mode01", "Mode22"]);
+                typeComboBox.SelectedIndex = 0;
+                typeComboBox.SelectedIndexChanged += (_, _) => UpdateTypeSpecificFields();
+
+                nameTextBox = new TextBox { Dock = DockStyle.Fill, Text = "New Mode01 Request" };
+                descriptionTextBox = new TextBox { Dock = DockStyle.Fill, Multiline = true, ScrollBars = ScrollBars.Vertical };
+                categoryTextBox = new TextBox { Dock = DockStyle.Fill };
+                unitTextBox = new TextBox { Dock = DockStyle.Fill };
+                pidsTextBox = new TextBox { Dock = DockStyle.Fill, Text = "0x0C" };
+                pidHighTextBox = new TextBox { Dock = DockStyle.Fill, Text = "0x00" };
+                pidLowTextBox = new TextBox { Dock = DockStyle.Fill, Text = "0x00" };
+
+                pidsLabel = CreateFieldLabel("PIDs");
+                pidHighLabel = CreateFieldLabel("PID High");
+                pidLowLabel = CreateFieldLabel("PID Low");
+
+                AddRow(layout, 0, "Type", typeComboBox);
+                AddRow(layout, 1, "Name", nameTextBox);
+                AddRow(layout, 2, "Description", descriptionTextBox);
+                AddRow(layout, 3, "Category", categoryTextBox);
+                AddRow(layout, 4, "Unit", unitTextBox);
+                AddControl(layout, 5, pidsLabel, pidsTextBox);
+                AddControl(layout, 6, pidHighLabel, pidHighTextBox);
+                AddControl(layout, 7, pidLowLabel, pidLowTextBox);
+
+                var buttonPanel = new FlowLayoutPanel
+                {
+                    Dock = DockStyle.Fill,
+                    AutoSize = true,
+                    FlowDirection = FlowDirection.RightToLeft,
+                    WrapContents = false,
+                    Margin = new Padding(0, 12, 0, 0),
+                    Padding = new Padding(0)
+                };
+
+                var cancelButton = new Button
+                {
+                    AutoSize = true,
+                    DialogResult = DialogResult.Cancel,
+                    Margin = new Padding(8, 0, 0, 0),
+                    Text = "Cancel"
+                };
+
+                var addButton = new Button
+                {
+                    AutoSize = true,
+                    Text = "Add"
+                };
+                addButton.Click += AddButton_Click;
+
+                buttonPanel.Controls.Add(cancelButton);
+                buttonPanel.Controls.Add(addButton);
+                layout.Controls.Add(buttonPanel, 1, 8);
+
+                Controls.Add(layout);
+                AcceptButton = addButton;
+                CancelButton = cancelButton;
+
+                UpdateTypeSpecificFields();
+            }
+
+            public EditableRequestRow BuildRow()
+            {
+                return new EditableRequestRow
+                {
+                    Type = typeComboBox.SelectedItem?.ToString() ?? "Mode01",
+                    Name = nameTextBox.Text.Trim(),
+                    Description = descriptionTextBox.Text.Trim(),
+                    Category = categoryTextBox.Text.Trim(),
+                    Unit = unitTextBox.Text.Trim(),
+                    PidsText = pidsTextBox.Text.Trim(),
+                    PidHighText = pidHighTextBox.Text.Trim(),
+                    PidLowText = pidLowTextBox.Text.Trim()
+                };
+            }
+
+            private static Label CreateFieldLabel(string text)
+            {
+                return new Label
+                {
+                    Text = text,
+                    TextAlign = ContentAlignment.MiddleLeft,
+                    Dock = DockStyle.Fill
+                };
+            }
+
+            private static void AddRow(TableLayoutPanel layout, int rowIndex, string labelText, Control control)
+            {
+                AddControl(layout, rowIndex, CreateFieldLabel(labelText), control);
+            }
+
+            private static void AddControl(TableLayoutPanel layout, int rowIndex, Control label, Control control)
+            {
+                layout.Controls.Add(label, 0, rowIndex);
+                layout.Controls.Add(control, 1, rowIndex);
+            }
+
+            private void UpdateTypeSpecificFields()
+            {
+                var isMode01 = string.Equals(typeComboBox.SelectedItem?.ToString(), "Mode01", StringComparison.OrdinalIgnoreCase);
+                pidsTextBox.Enabled = isMode01;
+                pidsLabel.Enabled = isMode01;
+                pidHighTextBox.Enabled = !isMode01;
+                pidLowTextBox.Enabled = !isMode01;
+                pidHighLabel.Enabled = !isMode01;
+                pidLowLabel.Enabled = !isMode01;
+
+                if (string.IsNullOrWhiteSpace(nameTextBox.Text) || nameTextBox.Text.StartsWith("New Mode", StringComparison.Ordinal))
+                {
+                    nameTextBox.Text = isMode01 ? "New Mode01 Request" : "New Mode22 Request";
+                    nameTextBox.SelectionStart = nameTextBox.TextLength;
+                }
+            }
+
+            private void AddButton_Click(object? sender, EventArgs e)
+            {
+                if (string.IsNullOrWhiteSpace(nameTextBox.Text))
+                {
+                    MessageBox.Show(this, "Request name cannot be empty.", "Validation Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+
+                if (string.Equals(typeComboBox.SelectedItem?.ToString(), "Mode01", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (string.IsNullOrWhiteSpace(pidsTextBox.Text))
+                    {
+                        MessageBox.Show(this, "Mode01 requests need one or more PIDs.", "Validation Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        return;
+                    }
+                }
+                else if (string.IsNullOrWhiteSpace(pidHighTextBox.Text) || string.IsNullOrWhiteSpace(pidLowTextBox.Text))
+                {
+                    MessageBox.Show(this, "Mode22 requests need PID High and PID Low values.", "Validation Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+
+                DialogResult = DialogResult.OK;
+                Close();
+            }
         }
 
         private sealed class EditableRequestRow

--- a/LotusECMLogger/Controls/OBDLoggerControl.cs
+++ b/LotusECMLogger/Controls/OBDLoggerControl.cs
@@ -51,7 +51,7 @@ namespace LotusECMLogger.Controls
             InitializeListView();
 
             // Populate OBD config menu
-            PopulateObdConfigComboBox();
+            RefreshAvailableConfigurations();
 
             // Initial button state
             IsLogging = false;
@@ -65,7 +65,7 @@ namespace LotusECMLogger.Controls
             liveDataView.Columns.Add("Value", 100);
         }
 
-        private void PopulateObdConfigComboBox()
+        public void RefreshAvailableConfigurations(string? preferredConfigName = null)
         {
             obdConfigComboBox.Items.Clear();
             var configs = MultiECUConfigurationLoader.GetAvailableConfigurations();
@@ -81,9 +81,15 @@ namespace LotusECMLogger.Controls
             {
                 obdConfigComboBox.Items.Add(config);
             }
-            // Default to first config
-            obdConfigComboBox.SelectedIndex = 0;
-            selectedObdConfigName = configs[0];
+
+            var selectedConfig = preferredConfigName;
+            if (string.IsNullOrWhiteSpace(selectedConfig) || !configs.Contains(selectedConfig))
+            {
+                selectedConfig = configs.Contains(selectedObdConfigName) ? selectedObdConfigName : configs[0];
+            }
+
+            obdConfigComboBox.SelectedItem = selectedConfig;
+            selectedObdConfigName = selectedConfig;
         }
 
         private void ObdConfigComboBox_SelectedIndexChanged(object? sender, EventArgs e)

--- a/LotusECMLogger/MainWindow.Designer.cs
+++ b/LotusECMLogger/MainWindow.Designer.cs
@@ -41,6 +41,7 @@ namespace LotusECMLogger
             vehicleInfoTab = new TabPage();
             vehicleInfoControl = new LotusECMLogger.Controls.VehicleInfoControl();
             liveDataTab = new TabPage();
+            loggingConfigTab = new TabPage();
             codingDataTab = new TabPage();
             dtcTab = new TabPage();
             dtcControl = new LotusECMLogger.Controls.DTCControl();
@@ -123,6 +124,7 @@ namespace LotusECMLogger
             //
             mainTabControl.Controls.Add(vehicleInfoTab);
             mainTabControl.Controls.Add(liveDataTab);
+            mainTabControl.Controls.Add(loggingConfigTab);
             mainTabControl.Controls.Add(codingDataTab);
             mainTabControl.Controls.Add(dtcTab);
             mainTabControl.Controls.Add(obdResetTab);
@@ -166,6 +168,16 @@ namespace LotusECMLogger
             liveDataTab.TabIndex = 0;
             liveDataTab.Text = "Live Data";
             liveDataTab.UseVisualStyleBackColor = true;
+            //
+            // loggingConfigTab
+            //
+            loggingConfigTab.Location = new Point(4, 34);
+            loggingConfigTab.Margin = new Padding(4, 4, 4, 4);
+            loggingConfigTab.Name = "loggingConfigTab";
+            loggingConfigTab.Size = new Size(992, 643);
+            loggingConfigTab.TabIndex = 7;
+            loggingConfigTab.Text = "Logging Config Editor";
+            loggingConfigTab.UseVisualStyleBackColor = true;
             //
             // codingDataTab
             //
@@ -273,6 +285,7 @@ namespace LotusECMLogger
         private ToolStripStatusLabel refreshRateLabel;
         private TabControl mainTabControl;
         private TabPage liveDataTab;
+        private TabPage loggingConfigTab;
         private TabPage codingDataTab;
         private TabPage vehicleInfoTab;
         private LotusECMLogger.Controls.VehicleInfoControl vehicleInfoControl;

--- a/LotusECMLogger/MainWindow.cs
+++ b/LotusECMLogger/MainWindow.cs
@@ -36,6 +36,22 @@ namespace LotusECMLogger
                 // TODO don't ignore exceptions
             }
 
+            // Add logging configuration editor
+            try
+            {
+                var loggingConfigEditor = new LoggingConfigEditorControl
+                {
+                    Dock = DockStyle.Fill
+                };
+                loggingConfigEditor.ConfigurationSaved += configName => obdLoggerControl?.RefreshAvailableConfigurations(configName);
+                loggingConfigTab.Controls.Clear();
+                loggingConfigTab.Controls.Add(loggingConfigEditor);
+            }
+            catch
+            {
+                // TODO don't ignore exceptions
+            }
+
             // Replace ECU Coding tab content with modular control
             try
             {

--- a/LotusECMLogger/Services/LoggingConfigFileService.cs
+++ b/LotusECMLogger/Services/LoggingConfigFileService.cs
@@ -1,0 +1,222 @@
+using System.Text.Json;
+
+namespace LotusECMLogger.Services
+{
+    /// <summary>
+    /// Loads and saves editable logging configurations while preserving JSON metadata.
+    /// </summary>
+    public static class LoggingConfigFileService
+    {
+        private const string ConfigSubDir = "config\\obdLogger";
+
+        private static readonly JsonSerializerOptions ReadOptions = new()
+        {
+            PropertyNameCaseInsensitive = true,
+            AllowTrailingCommas = true,
+            ReadCommentHandling = JsonCommentHandling.Skip
+        };
+
+        private static readonly JsonSerializerOptions WriteOptions = new()
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
+        public static string GetPreferredConfigDirectory()
+        {
+            var workingDir = Path.GetFullPath(ConfigSubDir);
+            if (Directory.Exists(workingDir))
+            {
+                return workingDir;
+            }
+
+            var executableDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ConfigSubDir);
+            if (Directory.Exists(executableDir))
+            {
+                return executableDir;
+            }
+
+            Directory.CreateDirectory(workingDir);
+            return workingDir;
+        }
+
+        public static string? TryGetConfigPath(string configName)
+        {
+            if (string.IsNullOrWhiteSpace(configName))
+            {
+                return null;
+            }
+
+            var candidatePaths = new[]
+            {
+                Path.Combine(GetPreferredConfigDirectory(), $"{configName}.json"),
+                Path.Combine(Path.GetFullPath(ConfigSubDir), $"{configName}.json"),
+                Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ConfigSubDir, $"{configName}.json")
+            };
+
+            return candidatePaths
+                .Select(Path.GetFullPath)
+                .FirstOrDefault(File.Exists);
+        }
+
+        public static MultiECUConfigurationJson LoadEditableConfigFromName(string configName)
+        {
+            var filePath = TryGetConfigPath(configName);
+            if (filePath == null)
+            {
+                throw new FileNotFoundException($"Configuration '{configName}' not found.");
+            }
+
+            return LoadEditableConfig(filePath);
+        }
+
+        public static MultiECUConfigurationJson LoadEditableConfig(string filePath)
+        {
+            if (!File.Exists(filePath))
+            {
+                throw new FileNotFoundException($"Configuration file not found: {filePath}");
+            }
+
+            var jsonText = File.ReadAllText(filePath);
+            var config = JsonSerializer.Deserialize<MultiECUConfigurationJson>(jsonText, ReadOptions);
+            if (config == null)
+            {
+                throw new InvalidOperationException("Failed to deserialize configuration file.");
+            }
+
+            return NormalizeForEditor(config);
+        }
+
+        public static void SaveEditableConfig(MultiECUConfigurationJson config, string filePath)
+        {
+            var normalizedConfig = NormalizeBeforeSave(config);
+            var jsonText = JsonSerializer.Serialize(normalizedConfig, WriteOptions);
+
+            var directory = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            File.WriteAllText(filePath, jsonText);
+        }
+
+        public static MultiECUConfigurationJson CreateDefaultConfig()
+        {
+            return new MultiECUConfigurationJson
+            {
+                Name = "New Logging Configuration",
+                Description = "Custom logging profile",
+                Ecus =
+                [
+                    new ECUGroupJson
+                    {
+                        Name = ECUDefinition.ECM.Name,
+                        RequestId = ECUDefinition.ECM.RequestId,
+                        ResponseId = ECUDefinition.ECM.ResponseId,
+                        Requests = new List<OBDRequestJson>()
+                    }
+                ]
+            };
+        }
+
+        private static MultiECUConfigurationJson NormalizeForEditor(MultiECUConfigurationJson config)
+        {
+            if (config.Ecus is { Count: > 0 })
+            {
+                return new MultiECUConfigurationJson
+                {
+                    Name = config.Name ?? string.Empty,
+                    Description = config.Description ?? string.Empty,
+                    Ecus = config.Ecus.Select(CloneEcuGroup).ToList()
+                };
+            }
+
+            var header = config.EcmHeader is { Length: 4 }
+                ? config.EcmHeader
+                : ECUDefinition.ECM.GetRequestHeader();
+
+            uint requestId = (uint)((header[0] << 24) | (header[1] << 16) | (header[2] << 8) | header[3]);
+            uint responseId = requestId + 8;
+
+            return new MultiECUConfigurationJson
+            {
+                Name = string.IsNullOrWhiteSpace(config.Name) ? "Logging Configuration" : config.Name,
+                Description = config.Description,
+                Ecus =
+                [
+                    new ECUGroupJson
+                    {
+                        Name = ECUDefinition.ECM.Name,
+                        RequestId = requestId,
+                        ResponseId = responseId,
+                        Requests = (config.Requests ?? new List<OBDRequestJson>()).Select(CloneRequest).ToList()
+                    }
+                ]
+            };
+        }
+
+        private static MultiECUConfigurationJson NormalizeBeforeSave(MultiECUConfigurationJson config)
+        {
+            var groups = (config.Ecus ?? new List<ECUGroupJson>())
+                .Select(CloneEcuGroup)
+                .ToList();
+
+            if (groups.Count == 1)
+            {
+                var singleGroup = groups[0];
+                return new MultiECUConfigurationJson
+                {
+                    Name = config.Name?.Trim() ?? string.Empty,
+                    Description = config.Description?.Trim() ?? string.Empty,
+                    EcmHeader = BuildHeader(singleGroup.RequestId),
+                    Requests = singleGroup.Requests.Select(CloneRequest).ToList()
+                };
+            }
+
+            return new MultiECUConfigurationJson
+            {
+                Name = config.Name?.Trim() ?? string.Empty,
+                Description = config.Description?.Trim() ?? string.Empty,
+                Ecus = groups
+            };
+        }
+
+        private static ECUGroupJson CloneEcuGroup(ECUGroupJson group)
+        {
+            return new ECUGroupJson
+            {
+                Name = group.Name ?? string.Empty,
+                RequestId = group.RequestId,
+                ResponseId = group.ResponseId,
+                Requests = group.Requests.Select(CloneRequest).ToList()
+            };
+        }
+
+        private static OBDRequestJson CloneRequest(OBDRequestJson request)
+        {
+            return new OBDRequestJson
+            {
+                Type = request.Type ?? string.Empty,
+                Name = request.Name ?? string.Empty,
+                Description = request.Description ?? string.Empty,
+                Category = request.Category ?? string.Empty,
+                Unit = request.Unit ?? string.Empty,
+                Pids = request.Pids?.ToArray(),
+                PidHigh = request.PidHigh,
+                PidLow = request.PidLow
+            };
+        }
+
+        private static byte[] BuildHeader(uint requestId)
+        {
+            return
+            [
+                (byte)((requestId >> 24) & 0xFF),
+                (byte)((requestId >> 16) & 0xFF),
+                (byte)((requestId >> 8) & 0xFF),
+                (byte)(requestId & 0xFF)
+            ];
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a WinForms logging config editor tab so logging profiles can be created and updated without editing JSON
- add load/save helpers that preserve legacy and multi-ECU config formats
- refresh the live logger config picker after saves and enforce Mode22 requests before Mode01 requests

## Why
- editing logger profiles directly as JSON is cumbersome and easy to get wrong
- the app needed a guided UI for creating and maintaining logging configurations

<img width="998" height="684" alt="Screenshot 2026-04-08 at 9 09 23 PM" src="https://github.com/user-attachments/assets/b4c4def7-25d8-48fc-be61-f17d420c939f" />
<img width="1002" height="687" alt="Screenshot 2026-04-08 at 9 09 41 PM" src="https://github.com/user-attachments/assets/7396fea1-377a-46c0-aca7-2ee58235ccc4" />
<img width="397" height="297" alt="Screenshot 2026-04-08 at 9 09 15 PM" src="https://github.com/user-attachments/assets/7903c51e-8c53-4975-95b8-b919249ab0d3" />


## Validation
- tested locally
