### PR TITLE
[codex] Allow loading invalid ECU coding data

### DIFF
--- a/LotusECMLogger/Controls/EcuCodingControl.cs
+++ b/LotusECMLogger/Controls/EcuCodingControl.cs
@@ -9,6 +9,9 @@ namespace LotusECMLogger.Controls
 		private T6eCodingDecoder? originalCodingDecoder;
 		private T6eCodingDecoder? modifiedCodingDecoder;
 		private readonly Dictionary<string, Control> codingControls = new Dictionary<string, Control>();
+		private readonly Dictionary<string, Label> codingLabels = new Dictionary<string, Label>();
+		private readonly Dictionary<string, Label> codingValidationLabels = new Dictionary<string, Label>();
+		private readonly ToolTip validationToolTip;
 
 		private bool isLoggerActive;
 		public bool IsLoggerActive
@@ -26,6 +29,8 @@ namespace LotusECMLogger.Controls
 		{
 			this.service = service;
 			InitializeComponent();
+			components ??= new System.ComponentModel.Container();
+			validationToolTip = new ToolTip(components);
 
 			Dock = DockStyle.Fill;
 
@@ -48,13 +53,15 @@ namespace LotusECMLogger.Controls
 				readCodesButton.Enabled = false;
 				readCodesButton.Text = "Reading...";
 
-				originalCodingDecoder = service.ReadCoding();
-				modifiedCodingDecoder = originalCodingDecoder;
-
-				UpdateCodingView();
-				writeCodesButton.Enabled = !IsLoggerActive;
-				UpdateBitFieldLabel();
+				LoadCodingDecoder(service.ReadCoding());
 				MessageBox.Show("Coding data successfully read from ECU!", "Read Complete", MessageBoxButtons.OK, MessageBoxIcon.Information);
+			}
+			catch (InvalidEcuCodingDataException ex)
+			{
+				if (ShowInvalidCodingDataDialog(ex) == InvalidCodingLoadChoice.LoadAnyway)
+				{
+					LoadCodingDecoder(new T6eCodingDecoder(ex.CodingDataLow, ex.CodingDataHigh, validate: false));
+				}
 			}
 			catch (System.Exception ex)
 			{
@@ -65,6 +72,72 @@ namespace LotusECMLogger.Controls
 				readCodesButton.Enabled = !IsLoggerActive;
 				readCodesButton.Text = "Read Codes";
 			}
+		}
+
+		private void LoadCodingDecoder(T6eCodingDecoder decoder)
+		{
+			originalCodingDecoder = decoder;
+			modifiedCodingDecoder = originalCodingDecoder;
+
+			UpdateCodingView();
+			writeCodesButton.Enabled = !IsLoggerActive;
+			UpdateBitFieldLabel();
+		}
+
+		private enum InvalidCodingLoadChoice
+		{
+			Cancel,
+			LoadAnyway
+		}
+
+		private InvalidCodingLoadChoice ShowInvalidCodingDataDialog(InvalidEcuCodingDataException exception)
+		{
+			using var dialog = new Form
+			{
+				Text = "Invalid ECU Coding Data",
+				FormBorderStyle = FormBorderStyle.FixedDialog,
+				StartPosition = FormStartPosition.CenterParent,
+				MinimizeBox = false,
+				MaximizeBox = false,
+				ShowInTaskbar = false,
+				ClientSize = new Size(520, 190)
+			};
+
+			var messageLabel = new Label
+			{
+				AutoSize = false,
+				Location = new Point(16, 16),
+				Size = new Size(488, 106),
+				Text =
+					"The ECU coding data is invalid and may not match a supported configuration.\r\n\r\n" +
+					$"{exception.InnerException?.Message ?? exception.Message}\r\n\r\n" +
+					"You can cancel, or load the raw coding data anyway to correct it before writing changes."
+			};
+
+			var cancelButton = new Button
+			{
+				Text = "Cancel",
+				DialogResult = DialogResult.Cancel,
+				Size = new Size(100, 28),
+				Location = new Point(298, 146)
+			};
+
+			var loadAnywayButton = new Button
+			{
+				Text = "Load anyway",
+				DialogResult = DialogResult.OK,
+				Size = new Size(106, 28),
+				Location = new Point(404, 146)
+			};
+
+			dialog.Controls.Add(messageLabel);
+			dialog.Controls.Add(cancelButton);
+			dialog.Controls.Add(loadAnywayButton);
+			dialog.CancelButton = cancelButton;
+
+			return dialog.ShowDialog(FindForm()) == DialogResult.OK
+				? InvalidCodingLoadChoice.LoadAnyway
+				: InvalidCodingLoadChoice.Cancel;
 		}
 
 		private void writeCodesButton_Click(object? sender, EventArgs e)
@@ -255,6 +328,7 @@ namespace LotusECMLogger.Controls
 				ResetSingleControl(optionName);
 
 			saveCodingButton.Text = "Save Changes";
+			ApplyValidationHighlights();
 			UpdateBitFieldLabel();
 		}
 
@@ -265,6 +339,8 @@ namespace LotusECMLogger.Controls
 
 			codingScrollPanel.Controls.Clear();
 			codingControls.Clear();
+			codingLabels.Clear();
+			codingValidationLabels.Clear();
 
 			var optionNames = originalCodingDecoder.GetAvailableOptions();
 			int yPosition = 10;
@@ -279,6 +355,7 @@ namespace LotusECMLogger.Controls
 					Anchor = AnchorStyles.Top | AnchorStyles.Left
 				};
 				codingScrollPanel.Controls.Add(label);
+				codingLabels[optionName] = label;
 
 				Control control;
 				if (originalCodingDecoder.IsOptionNumeric(optionName))
@@ -305,15 +382,24 @@ namespace LotusECMLogger.Controls
 					};
 					var possibleValues = originalCodingDecoder.GetOptionPossibleValues(optionName);
 					comboBox.Items.AddRange(possibleValues);
-					comboBox.SelectedItem = originalCodingDecoder.GetOptionValue(optionName);
-                    comboBox.SelectedIndexChanged += (s, e) =>
-                    {
-                        var selectedItem = comboBox.SelectedItem?.ToString();
-                        if (selectedItem != null)
-                        {
-                            OnCodingValueChanged(optionName, selectedItem);
-                        }
-                    };
+					var rawValue = originalCodingDecoder.GetOptionRawValue(optionName);
+					if (rawValue >= 0 && rawValue < possibleValues.Length)
+					{
+						comboBox.SelectedIndex = rawValue;
+					}
+					else
+					{
+						comboBox.Items.Add($"Invalid raw value: {rawValue}");
+						comboBox.SelectedIndex = comboBox.Items.Count - 1;
+					}
+					comboBox.SelectedIndexChanged += (s, e) =>
+					{
+						var selectedItem = comboBox.SelectedItem?.ToString();
+						if (selectedItem != null && !selectedItem.StartsWith("Invalid raw value:", StringComparison.Ordinal))
+						{
+							OnCodingValueChanged(optionName, selectedItem);
+						}
+					};
 					comboBox.Anchor = AnchorStyles.Top | AnchorStyles.Left;
 					control = comboBox;
 				}
@@ -321,11 +407,23 @@ namespace LotusECMLogger.Controls
 				codingScrollPanel.Controls.Add(control);
 				codingControls[optionName] = control;
 
+				var validationLabel = new Label
+				{
+					AutoEllipsis = true,
+					ForeColor = Color.Firebrick,
+					Location = new Point(490, yPosition + 3),
+					Size = new Size(280, 20),
+					Visible = false
+				};
+				codingScrollPanel.Controls.Add(validationLabel);
+				codingValidationLabels[optionName] = validationLabel;
+
 				yPosition += 35;
 			}
 
 			saveCodingButton.Enabled = true;
 			resetCodingButton.Enabled = true;
+			ApplyValidationHighlights();
 			UpdateBitFieldLabel();
 		}
 
@@ -336,6 +434,7 @@ namespace LotusECMLogger.Controls
 				modifiedCodingDecoder = modifiedCodingDecoder!.SetOptionValue(optionName, value);
 				bool hasChanges = !modifiedCodingDecoder.BitField.Equals(originalCodingDecoder!.BitField);
 				saveCodingButton.Text = hasChanges ? "Save Changes*" : "Save Changes";
+				ApplyValidationHighlights();
 				UpdateBitFieldLabel();
 			}
 			catch (System.Exception ex)
@@ -351,9 +450,76 @@ namespace LotusECMLogger.Controls
 				return;
 
 			if (control is ComboBox comboBox)
-				comboBox.SelectedItem = originalCodingDecoder!.GetOptionValue(optionName);
+			{
+				var rawValue = originalCodingDecoder!.GetOptionRawValue(optionName);
+				var possibleValues = originalCodingDecoder.GetOptionPossibleValues(optionName);
+				if (rawValue >= 0 && rawValue < possibleValues.Length)
+					comboBox.SelectedIndex = rawValue;
+				else
+					comboBox.SelectedItem = $"Invalid raw value: {rawValue}";
+			}
 			else if (control is NumericUpDown numericUpDown)
 				numericUpDown.Value = originalCodingDecoder!.GetOptionRawValue(optionName);
+		}
+
+		private void ApplyValidationHighlights()
+		{
+			if (modifiedCodingDecoder == null)
+				return;
+
+			foreach (var label in codingLabels.Values)
+				label.ForeColor = SystemColors.ControlText;
+
+			foreach (var control in codingControls.Values)
+			{
+				control.BackColor = SystemColors.Window;
+				validationToolTip.SetToolTip(control, string.Empty);
+			}
+
+			foreach (var validationLabel in codingValidationLabels.Values)
+			{
+				validationLabel.Text = string.Empty;
+				validationLabel.Visible = false;
+				validationToolTip.SetToolTip(validationLabel, string.Empty);
+			}
+
+			var messagesByOption = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+			foreach (var issue in modifiedCodingDecoder.GetValidationIssues())
+			{
+				foreach (var optionName in issue.OptionNames)
+				{
+					if (!messagesByOption.TryGetValue(optionName, out var messages))
+					{
+						messages = new List<string>();
+						messagesByOption[optionName] = messages;
+					}
+					messages.Add(issue.Message);
+				}
+			}
+
+			foreach (var (optionName, messages) in messagesByOption)
+			{
+				var message = string.Join(Environment.NewLine, messages.Distinct());
+
+				if (codingLabels.TryGetValue(optionName, out var label))
+				{
+					label.ForeColor = Color.Firebrick;
+					validationToolTip.SetToolTip(label, message);
+				}
+
+				if (codingControls.TryGetValue(optionName, out var control))
+				{
+					control.BackColor = Color.MistyRose;
+					validationToolTip.SetToolTip(control, message);
+				}
+
+				if (codingValidationLabels.TryGetValue(optionName, out var validationLabel))
+				{
+					validationLabel.Text = "Invalid";
+					validationLabel.Visible = true;
+					validationToolTip.SetToolTip(validationLabel, message);
+				}
+			}
 		}
 
 		private void UpdateBitFieldLabel()
@@ -365,5 +531,3 @@ namespace LotusECMLogger.Controls
 		}
 	}
 }
-
-

--- a/LotusECMLogger/Services/InvalidEcuCodingDataException.cs
+++ b/LotusECMLogger/Services/InvalidEcuCodingDataException.cs
@@ -1,0 +1,16 @@
+namespace LotusECMLogger.Services
+{
+	public sealed class InvalidEcuCodingDataException : InvalidOperationException
+	{
+		public InvalidEcuCodingDataException(byte[] codingDataLow, byte[] codingDataHigh, Exception innerException)
+			: base($"Invalid ECU coding data: {innerException.Message}", innerException)
+		{
+			CodingDataLow = (byte[])codingDataLow.Clone();
+			CodingDataHigh = (byte[])codingDataHigh.Clone();
+		}
+
+		public byte[] CodingDataLow { get; }
+
+		public byte[] CodingDataHigh { get; }
+	}
+}

--- a/LotusECMLogger/Services/J2534EcuCodingService.cs
+++ b/LotusECMLogger/Services/J2534EcuCodingService.cs
@@ -75,7 +75,14 @@ namespace LotusECMLogger.Services
 				}
 			} while (done != 3);
 
-			return new T6eCodingDecoder(result_cod1, result_cod0);
+			try
+			{
+				return new T6eCodingDecoder(result_cod1, result_cod0);
+			}
+			catch (ArgumentException ex)
+			{
+				throw new InvalidEcuCodingDataException(result_cod1, result_cod0, ex);
+			}
 		}
 
 		private static (bool success, string errorMessage) WriteRawCanCoding(T6eCodingDecoder codingDecoder, Device device)
@@ -108,5 +115,4 @@ namespace LotusECMLogger.Services
 		}
 	}
 }
-
 

--- a/LotusECMLogger/T6eCodingDecoder.cs
+++ b/LotusECMLogger/T6eCodingDecoder.cs
@@ -29,6 +29,8 @@ namespace LotusECMLogger
             public string[] Options { get; set; } = options;
         }
 
+        public sealed record CodingValidationIssue(string Message, string[] OptionNames);
+
         /// <summary>
         /// All coding options defined for the T6e ECU
         /// </summary>
@@ -102,8 +104,9 @@ namespace LotusECMLogger
         /// </summary>
         /// <param name="codingDataLow">Lower 4 bytes of coding data</param>
         /// <param name="codingDataHigh">Higher 4 bytes of coding data</param>
+        /// <param name="validate">When true, validates coding values against known ECU rules</param>
         /// <exception cref="ArgumentException">Thrown if either array is not exactly 4 bytes</exception>
-        public T6eCodingDecoder(byte[] codingDataLow, byte[] codingDataHigh)
+        public T6eCodingDecoder(byte[] codingDataLow, byte[] codingDataHigh, bool validate = true)
         {
             if (codingDataLow == null || codingDataLow.Length != 4)
             {
@@ -133,8 +136,8 @@ namespace LotusECMLogger
             // Combine into 64-bit field
             _bitField = (highBits << 32) | lowBits;
 
-            // TODO, add other validation rules from S2, Exige, and Emira
-            S1EvoraValidateCoding(_bitField);
+            if (validate)
+                ThrowIfInvalidCoding(_bitField);
 
         }
 
@@ -188,59 +191,90 @@ namespace LotusECMLogger
             return (int)((_bitField >> bitPosition) & (ulong)bitMask);
         }
 
-        /// <summary>
-        /// Validates that the coding data values are legal
-        /// </summary>
-        /// <param name="codingDataLow">Lower 4 bytes of coding data</param>
-        /// <param name="codingDataHigh">Higher 4 bytes of coding data</param>
-        /// <exception cref="ArgumentException">Thrown if coding data contains invalid values</exception>
-        private static void S1EvoraValidateCoding(ulong bitfield)
+        private static void ThrowIfInvalidCoding(ulong bitfield)
         {
-            if (bitfield == 0) {
-                return;
-            }
+            var firstIssue = GetValidationIssues(bitfield).FirstOrDefault();
+            if (firstIssue != null)
+                throw new ArgumentException(firstIssue.Message);
+        }
+
+        public IReadOnlyList<CodingValidationIssue> GetValidationIssues()
+        {
+            return GetValidationIssues(_bitField);
+        }
+
+        private static IReadOnlyList<CodingValidationIssue> GetValidationIssues(ulong bitfield)
+        {
+            var issues = new List<CodingValidationIssue>();
+            if (bitfield == 0)
+                return issues;
 
             // Convert byte arrays to 32-bit values for bit operations (little endian)
             uint codingHigh = (uint)(bitfield >> 32);
             uint codingLow = (uint)(bitfield & 0xFFFFFFFF);
 
+            foreach (var option in _codingOptions)
+            {
+                int value = (int)((bitfield >> option.BitPosition) & (ulong)option.BitMask);
+                if (option.Options != null && value >= option.Options.Length)
+                {
+                    issues.Add(new CodingValidationIssue(
+                        $"Invalid coding data: {option.Name} has raw value {value}, but valid values are 0-{option.Options.Length - 1}",
+                        [option.Name]));
+                }
+            }
+
             // Condition 1: (COD_base[0] >> 0x1c & 7) < 3
             if ((codingHigh >> 0x1c & 7) >= 3)
             {
-                throw new ArgumentException("Invalid coding data: bits 28-30 of codingDataHigh must be < 3");
+                issues.Add(new CodingValidationIssue(
+                    "Invalid coding data: bits 28-30 of codingDataHigh must be < 3",
+                    ["Heating Ventilation Air Conditioning"]));
             }
 
             // Condition 2: (COD_base[0] >> 0x19 & 7) < 2
             if ((codingHigh >> 0x19 & 7) >= 2)
             {
-                throw new ArgumentException("Invalid coding data: bits 25-27 of codingDataHigh must be < 2");
+                issues.Add(new CodingValidationIssue(
+                    "Invalid coding data: bits 25-27 of codingDataHigh must be < 2",
+                    ["Cruise System"]));
             }
 
             // Condition 3: ((COD_base[0] >> 0x16 & 7) == 3 || (COD_base[0] >> 0x16 & 7) == 1)
             uint bits22to24 = codingHigh >> 0x16 & 7;
             if (bits22to24 != 3 && bits22to24 != 1)
             {
-                throw new ArgumentException($"Invalid coding data: ({bits22to24}). Bits 22-24 of codingDataHigh must be 1 or 3");
+                issues.Add(new CodingValidationIssue(
+                    $"Invalid coding data: ({bits22to24}). Bits 22-24 of codingDataHigh must be 1 or 3",
+                    ["Traction Control Level"]));
             }
 
             // Condition 4: ((COD_base[0] >> 0xd & 7) != 1 || (COD_base[0] >> 0x16 & 7) == 3)
             uint bits13to15 = codingHigh >> 0xd & 7;
             if (bits13to15 == 1 && bits22to24 != 3)
             {
-                throw new ArgumentException($"Invalid coding data({bits13to15}): if bits 13-15 of codingDataHigh are 1, then bits 22-24 must be 3");
+                issues.Add(new CodingValidationIssue(
+                    $"Invalid coding data({bits13to15}): if bits 13-15 of codingDataHigh are 1, then bits 22-24 must be 3",
+                    ["Transmission Type", "Traction Control Level"]));
             }
 
             // Condition 5: ((COD_base[0] >> 0xd & 7) != 0 || (COD_base[1] >> 0x15 & 3) == 2)
             if (bits13to15 == 0 && (codingLow >> 0x15 & 3) != 2)
             {
-                throw new ArgumentException("Invalid coding data: if bits 13-15 of codingDataHigh are 0, then bits 21-22 of codingDataLow must be 2");
+                issues.Add(new CodingValidationIssue(
+                    "Invalid coding data: if bits 13-15 of codingDataHigh are 0, then bits 21-22 of codingDataLow must be 2",
+                    ["Transmission Type", "Clutch Input"]));
             }
 
             // Condition 6: ((COD_base[1] >> 10 & 1) != 0 && (COD_base[1] >> 9 & 1) != 0)
             if ((codingLow >> 10 & 1) == 0 || (codingLow >> 9 & 1) == 0)
             {
-                throw new ArgumentException("Invalid coding data: bits 9 and 10 of codingDataLow must both be set");
+                issues.Add(new CodingValidationIssue(
+                    "Invalid coding data: bits 9 and 10 of codingDataLow must both be set",
+                    ["Instrument Cluster", "Anti-Lock Braking System"]));
             }
+
+            return issues;
         }
 
         /// <summary>
@@ -487,4 +521,4 @@ namespace LotusECMLogger
             return BitConverter.ToString(CodingData).Replace("-", " ");
         }
     }
-} 
+}


### PR DESCRIPTION
## Summary
- Preserve raw ECU coding bytes when validation fails while reading from the ECU.
- Add a Load anyway recovery path so invalid coding can be opened and corrected.
- Surface invalid coding flags inline in the editor with red row highlights, Invalid markers, and tooltips.

## Validation
- git diff --check
- dotnet build LotusECMLogger.sln -p:EnableWindowsTargeting=true could not run because dotnet is not available on PATH in this environment.