### PR TITLE
Emira unlock tooling client

### DIFF
--- a/LotusECMLogger/Controls/EngineeringAccessControl.Designer.cs
+++ b/LotusECMLogger/Controls/EngineeringAccessControl.Designer.cs
@@ -27,6 +27,18 @@ namespace LotusECMLogger.Controls
             statusPanel = new FlowLayoutPanel();
             statusLabel = new Label();
             statusValueLabel = new Label();
+            writeGroupBox = new GroupBox();
+            writeLayout = new TableLayoutPanel();
+            enableWritesCheck = new CheckBox();
+            transportLabel = new Label();
+            transportCombo = new ComboBox();
+            writeAddressLabel = new Label();
+            writeAddressTextBox = new TextBox();
+            writeBytesLabel = new Label();
+            writeBytesTextBox = new TextBox();
+            writeButtonPanel = new FlowLayoutPanel();
+            writeButton = new Button();
+            applyMagicButton = new Button();
             resultGroupBox = new GroupBox();
             resultTextBox = new TextBox();
             layoutPanel.SuspendLayout();
@@ -34,6 +46,9 @@ namespace LotusECMLogger.Controls
             configLayout.SuspendLayout();
             buttonPanel.SuspendLayout();
             statusPanel.SuspendLayout();
+            writeGroupBox.SuspendLayout();
+            writeLayout.SuspendLayout();
+            writeButtonPanel.SuspendLayout();
             resultGroupBox.SuspendLayout();
             SuspendLayout();
             //
@@ -42,12 +57,14 @@ namespace LotusECMLogger.Controls
             layoutPanel.ColumnCount = 1;
             layoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
             layoutPanel.Controls.Add(configGroupBox, 0, 0);
-            layoutPanel.Controls.Add(resultGroupBox, 0, 1);
+            layoutPanel.Controls.Add(writeGroupBox, 0, 1);
+            layoutPanel.Controls.Add(resultGroupBox, 0, 2);
             layoutPanel.Dock = DockStyle.Fill;
             layoutPanel.Location = new Point(14, 17);
             layoutPanel.Margin = new Padding(4, 5, 4, 5);
             layoutPanel.Name = "layoutPanel";
-            layoutPanel.RowCount = 2;
+            layoutPanel.RowCount = 3;
+            layoutPanel.RowStyles.Add(new RowStyle());
             layoutPanel.RowStyles.Add(new RowStyle());
             layoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
             layoutPanel.Size = new Size(1115, 966);
@@ -62,7 +79,7 @@ namespace LotusECMLogger.Controls
             configGroupBox.Margin = new Padding(4, 5, 4, 5);
             configGroupBox.Name = "configGroupBox";
             configGroupBox.Padding = new Padding(14, 17, 14, 17);
-            configGroupBox.Size = new Size(1107, 200);
+            configGroupBox.Size = new Size(1107, 170);
             configGroupBox.TabIndex = 0;
             configGroupBox.TabStop = false;
             configGroupBox.Text = "Engineering Access Probe (read-only)";
@@ -85,7 +102,7 @@ namespace LotusECMLogger.Controls
             configLayout.RowStyles.Add(new RowStyle());
             configLayout.RowStyles.Add(new RowStyle());
             configLayout.RowStyles.Add(new RowStyle());
-            configLayout.Size = new Size(1079, 142);
+            configLayout.Size = new Size(1079, 112);
             configLayout.TabIndex = 0;
             //
             // profileLabel
@@ -166,18 +183,175 @@ namespace LotusECMLogger.Controls
             statusValueLabel.TabIndex = 1;
             statusValueLabel.Text = "Idle";
             //
+            // writeGroupBox
+            //
+            writeGroupBox.AutoSize = true;
+            writeGroupBox.Controls.Add(writeLayout);
+            writeGroupBox.Dock = DockStyle.Fill;
+            writeGroupBox.ForeColor = Color.Firebrick;
+            writeGroupBox.Location = new Point(4, 185);
+            writeGroupBox.Margin = new Padding(4, 5, 4, 5);
+            writeGroupBox.Name = "writeGroupBox";
+            writeGroupBox.Padding = new Padding(14, 17, 14, 17);
+            writeGroupBox.Size = new Size(1107, 230);
+            writeGroupBox.TabIndex = 1;
+            writeGroupBox.TabStop = false;
+            writeGroupBox.Text = "Live Memory Write (advanced — modifies the ECU)";
+            //
+            // writeLayout
+            //
+            writeLayout.AutoSize = true;
+            writeLayout.ColumnCount = 2;
+            writeLayout.ColumnStyles.Add(new ColumnStyle());
+            writeLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            writeLayout.Controls.Add(enableWritesCheck, 0, 0);
+            writeLayout.Controls.Add(transportLabel, 0, 1);
+            writeLayout.Controls.Add(transportCombo, 1, 1);
+            writeLayout.Controls.Add(writeAddressLabel, 0, 2);
+            writeLayout.Controls.Add(writeAddressTextBox, 1, 2);
+            writeLayout.Controls.Add(writeBytesLabel, 0, 3);
+            writeLayout.Controls.Add(writeBytesTextBox, 1, 3);
+            writeLayout.Controls.Add(writeButtonPanel, 1, 4);
+            writeLayout.Dock = DockStyle.Fill;
+            writeLayout.Location = new Point(14, 41);
+            writeLayout.Margin = new Padding(4, 5, 4, 5);
+            writeLayout.Name = "writeLayout";
+            writeLayout.RowCount = 5;
+            writeLayout.RowStyles.Add(new RowStyle());
+            writeLayout.RowStyles.Add(new RowStyle());
+            writeLayout.RowStyles.Add(new RowStyle());
+            writeLayout.RowStyles.Add(new RowStyle());
+            writeLayout.RowStyles.Add(new RowStyle());
+            writeLayout.Size = new Size(1079, 172);
+            writeLayout.TabIndex = 0;
+            //
+            // enableWritesCheck
+            //
+            enableWritesCheck.AutoSize = true;
+            writeLayout.SetColumnSpan(enableWritesCheck, 2);
+            enableWritesCheck.ForeColor = SystemColors.ControlText;
+            enableWritesCheck.Location = new Point(4, 5);
+            enableWritesCheck.Margin = new Padding(4, 5, 4, 5);
+            enableWritesCheck.Name = "enableWritesCheck";
+            enableWritesCheck.Size = new Size(400, 29);
+            enableWritesCheck.TabIndex = 0;
+            enableWritesCheck.Text = "Enable writes (I understand this modifies the ECU)";
+            enableWritesCheck.UseVisualStyleBackColor = true;
+            //
+            // transportLabel
+            //
+            transportLabel.Anchor = AnchorStyles.Left;
+            transportLabel.AutoSize = true;
+            transportLabel.ForeColor = SystemColors.ControlText;
+            transportLabel.Location = new Point(4, 47);
+            transportLabel.Margin = new Padding(4, 0, 4, 0);
+            transportLabel.Name = "transportLabel";
+            transportLabel.Size = new Size(90, 25);
+            transportLabel.TabIndex = 1;
+            transportLabel.Text = "Transport:";
+            //
+            // transportCombo
+            //
+            transportCombo.DropDownStyle = ComboBoxStyle.DropDownList;
+            transportCombo.Location = new Point(207, 44);
+            transportCombo.Margin = new Padding(4, 5, 4, 5);
+            transportCombo.Name = "transportCombo";
+            transportCombo.Size = new Size(400, 33);
+            transportCombo.TabIndex = 2;
+            //
+            // writeAddressLabel
+            //
+            writeAddressLabel.Anchor = AnchorStyles.Left;
+            writeAddressLabel.AutoSize = true;
+            writeAddressLabel.ForeColor = SystemColors.ControlText;
+            writeAddressLabel.Location = new Point(4, 88);
+            writeAddressLabel.Margin = new Padding(4, 0, 4, 0);
+            writeAddressLabel.Name = "writeAddressLabel";
+            writeAddressLabel.Size = new Size(150, 25);
+            writeAddressLabel.TabIndex = 3;
+            writeAddressLabel.Text = "Address (hex):";
+            //
+            // writeAddressTextBox
+            //
+            writeAddressTextBox.Location = new Point(207, 85);
+            writeAddressTextBox.Margin = new Padding(4, 5, 4, 5);
+            writeAddressTextBox.Name = "writeAddressTextBox";
+            writeAddressTextBox.Size = new Size(284, 31);
+            writeAddressTextBox.TabIndex = 4;
+            writeAddressTextBox.Text = "0x40000000";
+            //
+            // writeBytesLabel
+            //
+            writeBytesLabel.Anchor = AnchorStyles.Left;
+            writeBytesLabel.AutoSize = true;
+            writeBytesLabel.ForeColor = SystemColors.ControlText;
+            writeBytesLabel.Location = new Point(4, 129);
+            writeBytesLabel.Margin = new Padding(4, 0, 4, 0);
+            writeBytesLabel.Name = "writeBytesLabel";
+            writeBytesLabel.Size = new Size(150, 25);
+            writeBytesLabel.TabIndex = 5;
+            writeBytesLabel.Text = "Bytes (hex):";
+            //
+            // writeBytesTextBox
+            //
+            writeBytesTextBox.Location = new Point(207, 126);
+            writeBytesTextBox.Margin = new Padding(4, 5, 4, 5);
+            writeBytesTextBox.Name = "writeBytesTextBox";
+            writeBytesTextBox.PlaceholderText = "e.g. 0D B8 45 D4";
+            writeBytesTextBox.Size = new Size(400, 31);
+            writeBytesTextBox.TabIndex = 6;
+            //
+            // writeButtonPanel
+            //
+            writeButtonPanel.AutoSize = true;
+            writeButtonPanel.Controls.Add(writeButton);
+            writeButtonPanel.Controls.Add(applyMagicButton);
+            writeButtonPanel.Dock = DockStyle.Fill;
+            writeButtonPanel.Location = new Point(203, 167);
+            writeButtonPanel.Margin = new Padding(0, 5, 0, 0);
+            writeButtonPanel.Name = "writeButtonPanel";
+            writeButtonPanel.Size = new Size(876, 45);
+            writeButtonPanel.TabIndex = 7;
+            writeButtonPanel.WrapContents = false;
+            //
+            // writeButton
+            //
+            writeButton.AutoSize = true;
+            writeButton.ForeColor = SystemColors.ControlText;
+            writeButton.Location = new Point(4, 5);
+            writeButton.Margin = new Padding(4, 5, 4, 5);
+            writeButton.Name = "writeButton";
+            writeButton.Size = new Size(184, 35);
+            writeButton.TabIndex = 0;
+            writeButton.Text = "Write Bytes";
+            writeButton.UseVisualStyleBackColor = true;
+            writeButton.Click += WriteButton_Click;
+            //
+            // applyMagicButton
+            //
+            applyMagicButton.AutoSize = true;
+            applyMagicButton.ForeColor = SystemColors.ControlText;
+            applyMagicButton.Location = new Point(196, 5);
+            applyMagicButton.Margin = new Padding(4, 5, 4, 5);
+            applyMagicButton.Name = "applyMagicButton";
+            applyMagicButton.Size = new Size(260, 35);
+            applyMagicButton.TabIndex = 1;
+            applyMagicButton.Text = "Apply Calibration Magic";
+            applyMagicButton.UseVisualStyleBackColor = true;
+            applyMagicButton.Click += ApplyMagicButton_Click;
+            //
             // resultGroupBox
             //
             resultGroupBox.Controls.Add(resultTextBox);
             resultGroupBox.Dock = DockStyle.Fill;
-            resultGroupBox.Location = new Point(4, 215);
+            resultGroupBox.Location = new Point(4, 425);
             resultGroupBox.Margin = new Padding(4, 10, 4, 5);
             resultGroupBox.Name = "resultGroupBox";
             resultGroupBox.Padding = new Padding(14, 17, 14, 17);
-            resultGroupBox.Size = new Size(1107, 746);
-            resultGroupBox.TabIndex = 1;
+            resultGroupBox.Size = new Size(1107, 536);
+            resultGroupBox.TabIndex = 2;
             resultGroupBox.TabStop = false;
-            resultGroupBox.Text = "Probe Result";
+            resultGroupBox.Text = "Result";
             //
             // resultTextBox
             //
@@ -189,7 +363,7 @@ namespace LotusECMLogger.Controls
             resultTextBox.Name = "resultTextBox";
             resultTextBox.ReadOnly = true;
             resultTextBox.ScrollBars = ScrollBars.Both;
-            resultTextBox.Size = new Size(1079, 688);
+            resultTextBox.Size = new Size(1079, 478);
             resultTextBox.TabIndex = 0;
             resultTextBox.Text = "No probe run yet.";
             resultTextBox.WordWrap = false;
@@ -213,6 +387,12 @@ namespace LotusECMLogger.Controls
             buttonPanel.PerformLayout();
             statusPanel.ResumeLayout(false);
             statusPanel.PerformLayout();
+            writeGroupBox.ResumeLayout(false);
+            writeGroupBox.PerformLayout();
+            writeLayout.ResumeLayout(false);
+            writeLayout.PerformLayout();
+            writeButtonPanel.ResumeLayout(false);
+            writeButtonPanel.PerformLayout();
             resultGroupBox.ResumeLayout(false);
             resultGroupBox.PerformLayout();
             ResumeLayout(false);
@@ -231,6 +411,18 @@ namespace LotusECMLogger.Controls
         private FlowLayoutPanel statusPanel;
         private Label statusLabel;
         private Label statusValueLabel;
+        private GroupBox writeGroupBox;
+        private TableLayoutPanel writeLayout;
+        private CheckBox enableWritesCheck;
+        private Label transportLabel;
+        private ComboBox transportCombo;
+        private Label writeAddressLabel;
+        private TextBox writeAddressTextBox;
+        private Label writeBytesLabel;
+        private TextBox writeBytesTextBox;
+        private FlowLayoutPanel writeButtonPanel;
+        private Button writeButton;
+        private Button applyMagicButton;
         private GroupBox resultGroupBox;
         private TextBox resultTextBox;
     }

--- a/LotusECMLogger/Controls/EngineeringAccessControl.Designer.cs
+++ b/LotusECMLogger/Controls/EngineeringAccessControl.Designer.cs
@@ -1,0 +1,237 @@
+namespace LotusECMLogger.Controls
+{
+    partial class EngineeringAccessControl
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && components != null)
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        private void InitializeComponent()
+        {
+            layoutPanel = new TableLayoutPanel();
+            configGroupBox = new GroupBox();
+            configLayout = new TableLayoutPanel();
+            profileLabel = new Label();
+            profileCombo = new ComboBox();
+            buttonPanel = new FlowLayoutPanel();
+            runButton = new Button();
+            statusPanel = new FlowLayoutPanel();
+            statusLabel = new Label();
+            statusValueLabel = new Label();
+            resultGroupBox = new GroupBox();
+            resultTextBox = new TextBox();
+            layoutPanel.SuspendLayout();
+            configGroupBox.SuspendLayout();
+            configLayout.SuspendLayout();
+            buttonPanel.SuspendLayout();
+            statusPanel.SuspendLayout();
+            resultGroupBox.SuspendLayout();
+            SuspendLayout();
+            //
+            // layoutPanel
+            //
+            layoutPanel.ColumnCount = 1;
+            layoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            layoutPanel.Controls.Add(configGroupBox, 0, 0);
+            layoutPanel.Controls.Add(resultGroupBox, 0, 1);
+            layoutPanel.Dock = DockStyle.Fill;
+            layoutPanel.Location = new Point(14, 17);
+            layoutPanel.Margin = new Padding(4, 5, 4, 5);
+            layoutPanel.Name = "layoutPanel";
+            layoutPanel.RowCount = 2;
+            layoutPanel.RowStyles.Add(new RowStyle());
+            layoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            layoutPanel.Size = new Size(1115, 966);
+            layoutPanel.TabIndex = 0;
+            //
+            // configGroupBox
+            //
+            configGroupBox.AutoSize = true;
+            configGroupBox.Controls.Add(configLayout);
+            configGroupBox.Dock = DockStyle.Fill;
+            configGroupBox.Location = new Point(4, 5);
+            configGroupBox.Margin = new Padding(4, 5, 4, 5);
+            configGroupBox.Name = "configGroupBox";
+            configGroupBox.Padding = new Padding(14, 17, 14, 17);
+            configGroupBox.Size = new Size(1107, 200);
+            configGroupBox.TabIndex = 0;
+            configGroupBox.TabStop = false;
+            configGroupBox.Text = "Engineering Access Probe (read-only)";
+            //
+            // configLayout
+            //
+            configLayout.AutoSize = true;
+            configLayout.ColumnCount = 2;
+            configLayout.ColumnStyles.Add(new ColumnStyle());
+            configLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            configLayout.Controls.Add(profileLabel, 0, 0);
+            configLayout.Controls.Add(profileCombo, 1, 0);
+            configLayout.Controls.Add(buttonPanel, 1, 1);
+            configLayout.Controls.Add(statusPanel, 1, 2);
+            configLayout.Dock = DockStyle.Fill;
+            configLayout.Location = new Point(14, 41);
+            configLayout.Margin = new Padding(4, 5, 4, 5);
+            configLayout.Name = "configLayout";
+            configLayout.RowCount = 3;
+            configLayout.RowStyles.Add(new RowStyle());
+            configLayout.RowStyles.Add(new RowStyle());
+            configLayout.RowStyles.Add(new RowStyle());
+            configLayout.Size = new Size(1079, 142);
+            configLayout.TabIndex = 0;
+            //
+            // profileLabel
+            //
+            profileLabel.Anchor = AnchorStyles.Left;
+            profileLabel.AutoSize = true;
+            profileLabel.Location = new Point(4, 8);
+            profileLabel.Margin = new Padding(4, 0, 4, 0);
+            profileLabel.Name = "profileLabel";
+            profileLabel.Size = new Size(100, 25);
+            profileLabel.TabIndex = 0;
+            profileLabel.Text = "ECU Profile:";
+            //
+            // profileCombo
+            //
+            profileCombo.DropDownStyle = ComboBoxStyle.DropDownList;
+            profileCombo.Location = new Point(207, 5);
+            profileCombo.Margin = new Padding(4, 5, 4, 5);
+            profileCombo.Name = "profileCombo";
+            profileCombo.Size = new Size(400, 33);
+            profileCombo.TabIndex = 1;
+            //
+            // buttonPanel
+            //
+            buttonPanel.AutoSize = true;
+            buttonPanel.Controls.Add(runButton);
+            buttonPanel.Dock = DockStyle.Fill;
+            buttonPanel.Location = new Point(203, 48);
+            buttonPanel.Margin = new Padding(0, 5, 0, 0);
+            buttonPanel.Name = "buttonPanel";
+            buttonPanel.Size = new Size(876, 45);
+            buttonPanel.TabIndex = 2;
+            buttonPanel.WrapContents = false;
+            //
+            // runButton
+            //
+            runButton.AutoSize = true;
+            runButton.Location = new Point(4, 5);
+            runButton.Margin = new Padding(4, 5, 4, 5);
+            runButton.Name = "runButton";
+            runButton.Size = new Size(184, 35);
+            runButton.TabIndex = 0;
+            runButton.Text = "Run Probe";
+            runButton.UseVisualStyleBackColor = true;
+            runButton.Click += RunButton_Click;
+            //
+            // statusPanel
+            //
+            statusPanel.AutoSize = true;
+            statusPanel.Controls.Add(statusLabel);
+            statusPanel.Controls.Add(statusValueLabel);
+            statusPanel.Dock = DockStyle.Fill;
+            statusPanel.Location = new Point(203, 98);
+            statusPanel.Margin = new Padding(0, 5, 0, 0);
+            statusPanel.Name = "statusPanel";
+            statusPanel.Size = new Size(876, 39);
+            statusPanel.TabIndex = 3;
+            statusPanel.WrapContents = false;
+            //
+            // statusLabel
+            //
+            statusLabel.AutoSize = true;
+            statusLabel.Font = new Font("Segoe UI", 9F, FontStyle.Bold);
+            statusLabel.Location = new Point(4, 0);
+            statusLabel.Margin = new Padding(4, 7, 4, 0);
+            statusLabel.Name = "statusLabel";
+            statusLabel.Size = new Size(70, 25);
+            statusLabel.TabIndex = 0;
+            statusLabel.Text = "Status:";
+            //
+            // statusValueLabel
+            //
+            statusValueLabel.AutoSize = true;
+            statusValueLabel.Location = new Point(82, 0);
+            statusValueLabel.Margin = new Padding(4, 7, 4, 0);
+            statusValueLabel.Name = "statusValueLabel";
+            statusValueLabel.Size = new Size(41, 25);
+            statusValueLabel.TabIndex = 1;
+            statusValueLabel.Text = "Idle";
+            //
+            // resultGroupBox
+            //
+            resultGroupBox.Controls.Add(resultTextBox);
+            resultGroupBox.Dock = DockStyle.Fill;
+            resultGroupBox.Location = new Point(4, 215);
+            resultGroupBox.Margin = new Padding(4, 10, 4, 5);
+            resultGroupBox.Name = "resultGroupBox";
+            resultGroupBox.Padding = new Padding(14, 17, 14, 17);
+            resultGroupBox.Size = new Size(1107, 746);
+            resultGroupBox.TabIndex = 1;
+            resultGroupBox.TabStop = false;
+            resultGroupBox.Text = "Probe Result";
+            //
+            // resultTextBox
+            //
+            resultTextBox.Dock = DockStyle.Fill;
+            resultTextBox.Font = new Font("Consolas", 10F);
+            resultTextBox.Location = new Point(14, 41);
+            resultTextBox.Margin = new Padding(4, 5, 4, 5);
+            resultTextBox.Multiline = true;
+            resultTextBox.Name = "resultTextBox";
+            resultTextBox.ReadOnly = true;
+            resultTextBox.ScrollBars = ScrollBars.Both;
+            resultTextBox.Size = new Size(1079, 688);
+            resultTextBox.TabIndex = 0;
+            resultTextBox.Text = "No probe run yet.";
+            resultTextBox.WordWrap = false;
+            //
+            // EngineeringAccessControl
+            //
+            AutoScaleDimensions = new SizeF(10F, 25F);
+            AutoScaleMode = AutoScaleMode.Font;
+            Controls.Add(layoutPanel);
+            Margin = new Padding(4, 5, 4, 5);
+            Name = "EngineeringAccessControl";
+            Padding = new Padding(14, 17, 14, 17);
+            Size = new Size(1143, 1000);
+            layoutPanel.ResumeLayout(false);
+            layoutPanel.PerformLayout();
+            configGroupBox.ResumeLayout(false);
+            configGroupBox.PerformLayout();
+            configLayout.ResumeLayout(false);
+            configLayout.PerformLayout();
+            buttonPanel.ResumeLayout(false);
+            buttonPanel.PerformLayout();
+            statusPanel.ResumeLayout(false);
+            statusPanel.PerformLayout();
+            resultGroupBox.ResumeLayout(false);
+            resultGroupBox.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private TableLayoutPanel layoutPanel;
+        private GroupBox configGroupBox;
+        private TableLayoutPanel configLayout;
+        private Label profileLabel;
+        private ComboBox profileCombo;
+        private FlowLayoutPanel buttonPanel;
+        private Button runButton;
+        private FlowLayoutPanel statusPanel;
+        private Label statusLabel;
+        private Label statusValueLabel;
+        private GroupBox resultGroupBox;
+        private TextBox resultTextBox;
+    }
+}

--- a/LotusECMLogger/Controls/EngineeringAccessControl.cs
+++ b/LotusECMLogger/Controls/EngineeringAccessControl.cs
@@ -1,0 +1,134 @@
+using LotusECMLogger.Services;
+using System.ComponentModel;
+using System.Text;
+
+namespace LotusECMLogger.Controls
+{
+    /// <summary>
+    /// Read-only UI for the engineering-access probes. Lets the user pick an ECU profile and run
+    /// <see cref="IEngineeringAccessService.ProbeAsync"/>, then displays whether the raw memory
+    /// family is live, whether the proprietary tooling channel answers, and the state of the four
+    /// calibration-shadow predicate bytes. Performs no writes.
+    /// </summary>
+    public partial class EngineeringAccessControl : UserControl
+    {
+        private readonly IEngineeringAccessService service;
+        private bool isLoggerActive;
+        private bool isProbing;
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public bool IsLoggerActive
+        {
+            get => isLoggerActive;
+            set
+            {
+                isLoggerActive = value;
+                UpdateUIState();
+            }
+        }
+
+        public EngineeringAccessControl(IEngineeringAccessService service)
+        {
+            this.service = service ?? throw new ArgumentNullException(nameof(service));
+
+            InitializeComponent();
+
+            foreach (var profile in service.AvailableProfiles)
+                profileCombo.Items.Add(profile);
+            profileCombo.DisplayMember = nameof(EcuMemoryProfile.Name);
+            if (profileCombo.Items.Count > 0)
+                profileCombo.SelectedIndex = 0;
+
+            Dock = DockStyle.Fill;
+            UpdateUIState();
+        }
+
+        private async void RunButton_Click(object? sender, EventArgs e)
+        {
+            if (isLoggerActive)
+            {
+                MessageBox.Show("Cannot probe while the main logger is active. Stop the logger first.",
+                    "Logger Active", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            if (profileCombo.SelectedItem is not EcuMemoryProfile profile)
+                return;
+
+            try
+            {
+                isProbing = true;
+                UpdateUIState();
+                statusValueLabel.Text = "Probing…";
+                statusValueLabel.ForeColor = Color.Blue;
+                resultTextBox.Text = "Running probes…";
+
+                UnlockProbeReport report = await service.ProbeAsync(profile);
+
+                resultTextBox.Text = FormatReport(report);
+                statusValueLabel.Text = "Done";
+                statusValueLabel.ForeColor = Color.Black;
+            }
+            catch (Exception ex)
+            {
+                statusValueLabel.Text = "Error";
+                statusValueLabel.ForeColor = Color.Red;
+                resultTextBox.Text = $"Probe failed: {ex.Message}";
+            }
+            finally
+            {
+                isProbing = false;
+                UpdateUIState();
+            }
+        }
+
+        private static string FormatReport(UnlockProbeReport r)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"Profile: {r.ProfileName}");
+            sb.AppendLine();
+            sb.AppendLine($"Engineering memory family (ecu_unlocked): {(r.EngineeringAccessLive ? "LIVE — read answered" : "no response (locked or absent)")}");
+            sb.AppendLine($"Proprietary tooling channel:              {(r.ToolingChannelReachable ? "reachable" : "no response")}");
+
+            if (r.CalibrationMagic.Count == 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine("Calibration predicate: no magic pattern recovered for this profile.");
+                return sb.ToString();
+            }
+
+            sb.AppendLine($"Calibration predicate:                    {(r.CalibrationMagicComplete ? "COMPLETE (all bytes match)" : "incomplete / not all bytes match")}");
+            sb.AppendLine();
+            sb.AppendLine("  Address     Expected  Actual  Match");
+            sb.AppendLine("  ---------   --------  ------  -----");
+            foreach (var b in r.CalibrationMagic)
+            {
+                string actual = b.Read ? $"0x{b.Actual:X2}" : "--";
+                string match = !b.Read ? "?" : b.Matches ? "yes" : "NO";
+                sb.AppendLine($"  0x{b.Address:X8}  0x{b.Expected:X2}      {actual,-6}  {match}");
+            }
+            return sb.ToString();
+        }
+
+        private void UpdateUIState()
+        {
+            bool busy = isProbing || isLoggerActive;
+            runButton.Enabled = !busy && profileCombo.Items.Count > 0;
+            profileCombo.Enabled = !busy;
+
+            if (!isProbing)
+            {
+                if (isLoggerActive)
+                {
+                    statusValueLabel.Text = "Logger active — stop it to probe";
+                    statusValueLabel.ForeColor = Color.Gray;
+                }
+                else if (statusValueLabel.Text is "" or "Idle")
+                {
+                    statusValueLabel.Text = "Idle";
+                    statusValueLabel.ForeColor = Color.Black;
+                }
+            }
+        }
+    }
+}

--- a/LotusECMLogger/Controls/EngineeringAccessControl.cs
+++ b/LotusECMLogger/Controls/EngineeringAccessControl.cs
@@ -1,20 +1,20 @@
 using LotusECMLogger.Services;
 using System.ComponentModel;
+using System.Globalization;
 using System.Text;
 
 namespace LotusECMLogger.Controls
 {
     /// <summary>
-    /// Read-only UI for the engineering-access probes. Lets the user pick an ECU profile and run
-    /// <see cref="IEngineeringAccessService.ProbeAsync"/>, then displays whether the raw memory
-    /// family is live, whether the proprietary tooling channel answers, and the state of the four
-    /// calibration-shadow predicate bytes. Performs no writes.
+    /// UI for the engineering-access probes plus opt-in live-memory writes. The probe section is
+    /// read-only; the write section is disabled until the user explicitly enables it, and every
+    /// write is confirmed before it is sent.
     /// </summary>
     public partial class EngineeringAccessControl : UserControl
     {
         private readonly IEngineeringAccessService service;
         private bool isLoggerActive;
-        private bool isProbing;
+        private bool isBusy;
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsLoggerActive
@@ -38,34 +38,113 @@ namespace LotusECMLogger.Controls
             profileCombo.DisplayMember = nameof(EcuMemoryProfile.Name);
             if (profileCombo.Items.Count > 0)
                 profileCombo.SelectedIndex = 0;
+            profileCombo.SelectedIndexChanged += (_, _) => UpdateUIState();
+
+            transportCombo.Items.Add(EngineeringWriteTransport.ToolingChannel);
+            transportCombo.Items.Add(EngineeringWriteTransport.RmaFamily);
+            transportCombo.SelectedIndex = 0;
+
+            enableWritesCheck.CheckedChanged += (_, _) => UpdateUIState();
 
             Dock = DockStyle.Fill;
             UpdateUIState();
         }
 
+        private EcuMemoryProfile? SelectedProfile => profileCombo.SelectedItem as EcuMemoryProfile;
+
         private async void RunButton_Click(object? sender, EventArgs e)
         {
-            if (isLoggerActive)
+            if (!GuardReady()) return;
+            if (SelectedProfile is not EcuMemoryProfile profile) return;
+
+            await RunOperation("Probing…", async () =>
             {
-                MessageBox.Show("Cannot probe while the main logger is active. Stop the logger first.",
-                    "Logger Active", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                UnlockProbeReport report = await service.ProbeAsync(profile);
+                resultTextBox.Text = FormatReport(report);
+            });
+        }
+
+        private async void WriteButton_Click(object? sender, EventArgs e)
+        {
+            if (!GuardReady()) return;
+            if (SelectedProfile is not EcuMemoryProfile profile) return;
+
+            string addrText = writeAddressTextBox.Text.Trim();
+            if (addrText.StartsWith("0x", StringComparison.OrdinalIgnoreCase)) addrText = addrText[2..];
+            if (!uint.TryParse(addrText, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint address))
+            {
+                MessageBox.Show("Invalid address. Enter a hex address such as 0x40000000.",
+                    "Invalid Input", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
-            if (profileCombo.SelectedItem is not EcuMemoryProfile profile)
+            if (!TryParseHexBytes(writeBytesTextBox.Text, out byte[] data, out string parseError))
+            {
+                MessageBox.Show($"Invalid bytes: {parseError}",
+                    "Invalid Input", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
+            }
 
+            var transport = (EngineeringWriteTransport)transportCombo.SelectedItem!;
+            string hex = string.Join(" ", data.Select(b => b.ToString("X2")));
+            var confirm = MessageBox.Show(
+                $"Write {data.Length} byte(s) [{hex}] to 0x{address:X8} on {profile.Name} via {transport}?\n\n" +
+                "This modifies live ECU memory. Continue?",
+                "Confirm Write", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+            if (confirm != DialogResult.Yes) return;
+
+            await RunOperation("Writing…", async () =>
+            {
+                await service.WriteAsync(profile, transport, address, data);
+                resultTextBox.Text = $"Wrote {data.Length} byte(s) [{hex}] to 0x{address:X8} via {transport}.";
+            });
+        }
+
+        private async void ApplyMagicButton_Click(object? sender, EventArgs e)
+        {
+            if (!GuardReady()) return;
+            if (SelectedProfile is not EcuMemoryProfile profile) return;
+            if (profile.CalibrationMagic.Length == 0) return;
+
+            var confirm = MessageBox.Show(
+                $"Write the {profile.CalibrationMagic.Length} calibration-shadow magic bytes on {profile.Name} via the tooling channel?\n\n" +
+                "Per the firmware analysis this patches the RAM shadow only; it does NOT re-run the boot " +
+                "predicate or re-enable the engineering mailbox in the current session. It is a diagnostic " +
+                "experiment. Continue?",
+                "Confirm Calibration-Magic Write", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+            if (confirm != DialogResult.Yes) return;
+
+            await RunOperation("Applying magic bytes…", async () =>
+            {
+                await service.ApplyCalibrationMagicAsync(profile);
+                resultTextBox.Text =
+                    $"Wrote {profile.CalibrationMagic.Length} calibration-shadow magic bytes. " +
+                    "Run the probe again to read them back; note this does not unlock live (see firmware analysis).";
+            });
+        }
+
+        private bool GuardReady()
+        {
+            if (isLoggerActive)
+            {
+                MessageBox.Show("Cannot use engineering access while the main logger is active. Stop the logger first.",
+                    "Logger Active", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return false;
+            }
+            return !isBusy;
+        }
+
+        private async Task RunOperation(string statusText, Func<Task> op)
+        {
             try
             {
-                isProbing = true;
+                isBusy = true;
                 UpdateUIState();
-                statusValueLabel.Text = "Probing…";
+                statusValueLabel.Text = statusText;
                 statusValueLabel.ForeColor = Color.Blue;
-                resultTextBox.Text = "Running probes…";
 
-                UnlockProbeReport report = await service.ProbeAsync(profile);
+                await op();
 
-                resultTextBox.Text = FormatReport(report);
                 statusValueLabel.Text = "Done";
                 statusValueLabel.ForeColor = Color.Black;
             }
@@ -73,13 +152,54 @@ namespace LotusECMLogger.Controls
             {
                 statusValueLabel.Text = "Error";
                 statusValueLabel.ForeColor = Color.Red;
-                resultTextBox.Text = $"Probe failed: {ex.Message}";
+                resultTextBox.Text = $"Operation failed: {ex.Message}";
             }
             finally
             {
-                isProbing = false;
+                isBusy = false;
                 UpdateUIState();
             }
+        }
+
+        private static bool TryParseHexBytes(string text, out byte[] data, out string error)
+        {
+            data = [];
+            error = "";
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                error = "no bytes entered";
+                return false;
+            }
+
+            // Accept space/comma separated tokens ("0D B8 45") or a continuous string ("0DB845").
+            string cleaned = text.Replace("0x", "", StringComparison.OrdinalIgnoreCase)
+                                 .Replace(",", " ");
+            string[] tokens = cleaned.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            var bytes = new List<byte>();
+            if (tokens.Length == 1 && tokens[0].Length > 2)
+            {
+                string s = tokens[0];
+                if (s.Length % 2 != 0) { error = "continuous hex must have an even number of digits"; return false; }
+                for (int i = 0; i < s.Length; i += 2)
+                {
+                    if (!byte.TryParse(s.AsSpan(i, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out byte b))
+                    { error = $"'{s.Substring(i, 2)}' is not a hex byte"; return false; }
+                    bytes.Add(b);
+                }
+            }
+            else
+            {
+                foreach (var t in tokens)
+                {
+                    if (!byte.TryParse(t, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out byte b))
+                    { error = $"'{t}' is not a hex byte"; return false; }
+                    bytes.Add(b);
+                }
+            }
+
+            data = [.. bytes];
+            return true;
         }
 
         private static string FormatReport(UnlockProbeReport r)
@@ -112,15 +232,24 @@ namespace LotusECMLogger.Controls
 
         private void UpdateUIState()
         {
-            bool busy = isProbing || isLoggerActive;
-            runButton.Enabled = !busy && profileCombo.Items.Count > 0;
-            profileCombo.Enabled = !busy;
+            bool blocked = isBusy || isLoggerActive;
+            bool writesOn = enableWritesCheck.Checked && !blocked;
 
-            if (!isProbing)
+            runButton.Enabled = !blocked && profileCombo.Items.Count > 0;
+            profileCombo.Enabled = !blocked;
+            enableWritesCheck.Enabled = !blocked;
+
+            transportCombo.Enabled = writesOn;
+            writeAddressTextBox.Enabled = writesOn;
+            writeBytesTextBox.Enabled = writesOn;
+            writeButton.Enabled = writesOn;
+            applyMagicButton.Enabled = writesOn && SelectedProfile is { CalibrationMagic.Length: > 0 };
+
+            if (!isBusy)
             {
                 if (isLoggerActive)
                 {
-                    statusValueLabel.Text = "Logger active — stop it to probe";
+                    statusValueLabel.Text = "Logger active — stop it to use this tab";
                     statusValueLabel.ForeColor = Color.Gray;
                 }
                 else if (statusValueLabel.Text is "" or "Idle")

--- a/LotusECMLogger/MainWindow.Designer.cs
+++ b/LotusECMLogger/MainWindow.Designer.cs
@@ -53,6 +53,7 @@ namespace LotusECMLogger
             liveTuningTab = new TabPage();
             liveTuningControl = new LotusECMLogger.Controls.LiveTuningDiskMonitorControl();
             highSpeedLogTab = new TabPage();
+            engineeringAccessTab = new TabPage();
             menuStrip1.SuspendLayout();
             statusStrip1.SuspendLayout();
             mainTabControl.SuspendLayout();
@@ -143,6 +144,7 @@ namespace LotusECMLogger
             mainTabControl.Controls.Add(t6RmaTab);
             mainTabControl.Controls.Add(liveTuningTab);
             mainTabControl.Controls.Add(highSpeedLogTab);
+            mainTabControl.Controls.Add(engineeringAccessTab);
             mainTabControl.Dock = DockStyle.Fill;
             mainTabControl.Location = new Point(0, 37);
             mainTabControl.Margin = new Padding(4);
@@ -290,6 +292,16 @@ namespace LotusECMLogger
             highSpeedLogTab.Text = "High-Speed Log";
             highSpeedLogTab.UseVisualStyleBackColor = true;
             //
+            // engineeringAccessTab
+            //
+            engineeringAccessTab.Location = new Point(4, 64);
+            engineeringAccessTab.Margin = new Padding(4);
+            engineeringAccessTab.Name = "engineeringAccessTab";
+            engineeringAccessTab.Size = new Size(992, 613);
+            engineeringAccessTab.TabIndex = 8;
+            engineeringAccessTab.Text = "Engineering Access";
+            engineeringAccessTab.UseVisualStyleBackColor = true;
+            //
             // MainWindow
             //
             AutoScaleDimensions = new SizeF(10F, 25F);
@@ -344,5 +356,6 @@ namespace LotusECMLogger
         private TabPage liveTuningTab;
         private LotusECMLogger.Controls.LiveTuningDiskMonitorControl liveTuningControl;
         private TabPage highSpeedLogTab;
+        private TabPage engineeringAccessTab;
     }
 }

--- a/LotusECMLogger/MainWindow.cs
+++ b/LotusECMLogger/MainWindow.cs
@@ -96,6 +96,24 @@ namespace LotusECMLogger
                 MessageBox.Show($"Failed to initialize High-Speed Log tab: {ex.Message}", "Startup Error",
                     MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
+
+            // Add engineering-access probe control (read-only)
+            try
+            {
+                var engService = new EngineeringAccessService();
+                var engControl = new EngineeringAccessControl(engService)
+                {
+                    Dock = DockStyle.Fill,
+                    IsLoggerActive = false
+                };
+                engineeringAccessTab.Controls.Clear();
+                engineeringAccessTab.Controls.Add(engControl);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Failed to initialize Engineering Access tab: {ex.Message}", "Startup Error",
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
         }
 
         /// <summary>
@@ -118,6 +136,10 @@ namespace LotusECMLogger
                 var hsControl = highSpeedLogTab.Controls.OfType<HighSpeedLogControl>().FirstOrDefault();
                 if (hsControl != null)
                     hsControl.IsLoggerActive = isLogging;
+
+                var engControl = engineeringAccessTab.Controls.OfType<EngineeringAccessControl>().FirstOrDefault();
+                if (engControl != null)
+                    engControl.IsLoggerActive = isLogging;
 
                 // Erasing model info issues an RMA write, which conflicts with active logging.
                 eraseModelInfoToolStripMenuItem.Enabled = !isLogging;
@@ -180,7 +202,8 @@ namespace LotusECMLogger
                 GuiIcons.Dtc,
                 GuiIcons.RmaLogging,
                 GuiIcons.LiveTuning,
-                GuiIcons.HighSpeedLog);
+                GuiIcons.HighSpeedLog,
+                GuiIcons.Connect);
             mainTabControl.ImageList = mainIcons;
             vehicleInfoTab.ImageIndex = 0;
             liveDataTab.ImageIndex    = 1;
@@ -189,6 +212,7 @@ namespace LotusECMLogger
             t6RmaTab.ImageIndex       = 4;
             liveTuningTab.ImageIndex  = 5;
             highSpeedLogTab.ImageIndex = 6;
+            engineeringAccessTab.ImageIndex = 7;
 
             var loggingIcons = GuiIcons.BuildImageList(20, tabColor,
                 GuiIcons.LoggerTab,

--- a/LotusECMLogger/Services/EcuMemoryProfile.cs
+++ b/LotusECMLogger/Services/EcuMemoryProfile.cs
@@ -1,0 +1,113 @@
+namespace LotusECMLogger.Services
+{
+    /// <summary>
+    /// One of the four dispersed calibration bytes whose values gate the boot-time
+    /// <c>ecu_unlocked</c> engineering predicate. The firmware copies calibration flash
+    /// into the RAM shadow at startup, then requires all of these offsets to hold their
+    /// expected byte before enabling the raw engineering mailbox family.
+    /// </summary>
+    /// <param name="ShadowOffset">Byte offset within the RAM calibration shadow.</param>
+    /// <param name="ExpectedValue">Value the firmware compares against at that offset.</param>
+    public readonly record struct CalibrationMagicByte(uint ShadowOffset, byte ExpectedValue);
+
+    /// <summary>
+    /// CAN IDs and memory layout for a specific Lotus T6-family ECU. Everything the
+    /// unlock/tooling clients need is captured here so the same code can target either
+    /// the Evora T6e or the Emira G6 ECU (or a hand-tuned variant) from configuration.
+    ///
+    /// Sources:
+    ///   • Evora RMA IDs/window: existing T6RMAService (firmware flexcan_a_rx_50_51_52_53).
+    ///   • Emira engineering/tooling IDs, cal-shadow base and magic bytes:
+    ///     disassembly/emira/8896915220A_ROW/analysis/ENGINEERING_UNLOCK_PATHS.md.
+    /// </summary>
+    public sealed record EcuMemoryProfile
+    {
+        public required string Name { get; init; }
+
+        /// <summary>
+        /// Base standard CAN ID of the raw memory family. The eight operations are laid out
+        /// contiguously from this base: +0 read32, +1 read16, +2 read8, +3 block-read,
+        /// +4 write32, +5 write16, +6 write8, +7 block/stream-write.
+        /// Evora = 0x50, Emira = 0x40.
+        /// </summary>
+        public required uint RmaBaseId { get; init; }
+
+        /// <summary>CAN ID the ECU replies on for every raw memory read. Both ECUs use 0x7A0.</summary>
+        public required uint RmaResponseId { get; init; }
+
+        /// <summary>Inclusive start of the address window the raw memory family will service.</summary>
+        public required uint RamStart { get; init; }
+
+        /// <summary>Inclusive end of the address window the raw memory family will service.</summary>
+        public required uint RamEnd { get; init; }
+
+        /// <summary>
+        /// Request ID of the always-initialized proprietary tooling channel. This channel is
+        /// NOT gated by <c>ecu_unlocked</c>, which is why it is the interesting unlock surface.
+        /// Emira = 0x202. Unverified on the Evora — treat as a hypothesis to probe.
+        /// </summary>
+        public required uint ToolingRequestId { get; init; }
+
+        /// <summary>Response/stream IDs the tooling channel replies on. Emira = {0x200, 0x201}.</summary>
+        public required uint[] ToolingResponseIds { get; init; }
+
+        /// <summary>
+        /// Base address of the RAM calibration shadow (where calibration flash is copied at boot).
+        /// The magic bytes below are expressed as offsets into this region. Null when unknown.
+        /// Emira = 0x4002E000.
+        /// </summary>
+        public uint? CalShadowBase { get; init; }
+
+        /// <summary>
+        /// The dispersed calibration bytes that must match for the boot predicate to set
+        /// <c>ecu_unlocked = true</c>. Empty when the pattern for this ECU is not yet recovered.
+        /// </summary>
+        public CalibrationMagicByte[] CalibrationMagic { get; init; } = [];
+
+        /// <summary>Absolute address of a magic byte, or null if the shadow base is unknown.</summary>
+        public uint? MagicAddress(CalibrationMagicByte b) =>
+            CalShadowBase is uint baseAddr ? baseAddr + b.ShadowOffset : null;
+
+        /// <summary>
+        /// Evora T6e. RMA family 0x50-0x57 replying on 0x7A0 over the 64 KiB RAM window.
+        /// The tooling-channel IDs mirror the Emira as an untested cross-model hypothesis, and
+        /// the Evora's calibration magic offsets are not yet recovered here.
+        /// </summary>
+        public static readonly EcuMemoryProfile Evora = new()
+        {
+            Name = "Evora T6e",
+            RmaBaseId = 0x50,
+            RmaResponseId = 0x7A0,
+            RamStart = 0x40000000,
+            RamEnd = 0x4000FFFF,
+            ToolingRequestId = 0x202,
+            ToolingResponseIds = [0x200, 0x201],
+            CalShadowBase = null,
+            CalibrationMagic = [],
+        };
+
+        /// <summary>
+        /// Emira G6 (8896915220A_ROW). Raw engineering family 0x40-0x47 replying on 0x7A0 over
+        /// the 256 KiB SRAM window, plus the un-gated 0x202 tooling channel and the four
+        /// calibration-shadow magic bytes recovered in ENGINEERING_UNLOCK_PATHS.md.
+        /// </summary>
+        public static readonly EcuMemoryProfile Emira = new()
+        {
+            Name = "Emira G6 (8896915220A)",
+            RmaBaseId = 0x40,
+            RmaResponseId = 0x7A0,
+            RamStart = 0x40000000,
+            RamEnd = 0x4003FFFF,
+            ToolingRequestId = 0x202,
+            ToolingResponseIds = [0x200, 0x201],
+            CalShadowBase = 0x4002E000,
+            CalibrationMagic =
+            [
+                new CalibrationMagicByte(0x00E2, 0x0D),
+                new CalibrationMagicByte(0x0218, 0xB8),
+                new CalibrationMagicByte(0x0290, 0x45),
+                new CalibrationMagicByte(0x0337, 0xD4),
+            ],
+        };
+    }
+}

--- a/LotusECMLogger/Services/EngineeringAccessService.cs
+++ b/LotusECMLogger/Services/EngineeringAccessService.cs
@@ -1,0 +1,41 @@
+using System.Threading;
+using System.Threading.Tasks;
+using SAE.J2534;
+
+namespace LotusECMLogger.Services
+{
+    /// <summary>
+    /// J2534-backed implementation of <see cref="IEngineeringAccessService"/>. Each probe opens a
+    /// short-lived raw CAN channel with a pass-all filter, delegates to <see cref="T6eUnlockHelper"/>,
+    /// and disposes the session — mirroring the temporary-session pattern in T6RMAService.
+    /// </summary>
+    public sealed class EngineeringAccessService : IEngineeringAccessService
+    {
+        public IReadOnlyList<EcuMemoryProfile> AvailableProfiles { get; } =
+            [EcuMemoryProfile.Evora, EcuMemoryProfile.Emira];
+
+        public Task<UnlockProbeReport> ProbeAsync(EcuMemoryProfile profile, CancellationToken ct = default)
+        {
+            if (profile is null) throw new ArgumentNullException(nameof(profile));
+
+            // J2534 device open + polling are blocking, so run off the UI thread.
+            return Task.Run(async () =>
+            {
+                using var session = J2534Session.Open();
+                J2534Channel channel = session.OpenCan();
+
+                // Pass every 11-bit CAN ID; the clients filter to their response IDs in software.
+                var passAll = new MessageFilter
+                {
+                    FilterType = Filter.PASS_FILTER,
+                    Mask = [0x00, 0x00, 0x00, 0x00],
+                    Pattern = [0x00, 0x00, 0x00, 0x00],
+                };
+                channel.StartMessageFilter(passAll).ThrowIfError();
+
+                var helper = new T6eUnlockHelper(channel, profile);
+                return await helper.ProbeAsync(ct);
+            }, ct);
+        }
+    }
+}

--- a/LotusECMLogger/Services/EngineeringAccessService.cs
+++ b/LotusECMLogger/Services/EngineeringAccessService.cs
@@ -5,26 +5,81 @@ using SAE.J2534;
 namespace LotusECMLogger.Services
 {
     /// <summary>
-    /// J2534-backed implementation of <see cref="IEngineeringAccessService"/>. Each probe opens a
-    /// short-lived raw CAN channel with a pass-all filter, delegates to <see cref="T6eUnlockHelper"/>,
-    /// and disposes the session — mirroring the temporary-session pattern in T6RMAService.
+    /// J2534-backed implementation of <see cref="IEngineeringAccessService"/>. Each operation opens
+    /// a short-lived raw CAN channel with a pass-all filter, delegates to the T6e clients, and
+    /// disposes the session — mirroring the temporary-session pattern in T6RMAService.
     /// </summary>
     public sealed class EngineeringAccessService : IEngineeringAccessService
     {
+        private const int ToolingChunk = 5; // tooling channel moves at most five bytes per frame
+
         public IReadOnlyList<EcuMemoryProfile> AvailableProfiles { get; } =
             [EcuMemoryProfile.Evora, EcuMemoryProfile.Emira];
 
         public Task<UnlockProbeReport> ProbeAsync(EcuMemoryProfile profile, CancellationToken ct = default)
         {
             if (profile is null) throw new ArgumentNullException(nameof(profile));
+            return RunWithChannelAsync(async channel =>
+            {
+                var helper = new T6eUnlockHelper(channel, profile);
+                return await helper.ProbeAsync(ct);
+            }, ct);
+        }
 
-            // J2534 device open + polling are blocking, so run off the UI thread.
+        public Task WriteAsync(EcuMemoryProfile profile, EngineeringWriteTransport transport, uint address, byte[] data, CancellationToken ct = default)
+        {
+            if (profile is null) throw new ArgumentNullException(nameof(profile));
+            if (data is null || data.Length == 0) throw new ArgumentException("No bytes to write.", nameof(data));
+
+            return RunWithChannelAsync<object?>(async channel =>
+            {
+                switch (transport)
+                {
+                    case EngineeringWriteTransport.RmaFamily:
+                        var rma = new T6eRMAClient(channel, profile) { AllowWrites = true };
+                        await rma.Write(address, data, ct);
+                        break;
+
+                    case EngineeringWriteTransport.ToolingChannel:
+                        var tooling = new T6eToolingClient(channel, profile) { AllowWrites = true };
+                        for (int offset = 0; offset < data.Length; offset += ToolingChunk)
+                        {
+                            int len = Math.Min(ToolingChunk, data.Length - offset);
+                            await tooling.WriteAsync((uint)(address + offset), data.AsMemory(offset, len), ct);
+                        }
+                        break;
+
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(transport));
+                }
+                return null;
+            }, ct);
+        }
+
+        public Task ApplyCalibrationMagicAsync(EcuMemoryProfile profile, CancellationToken ct = default)
+        {
+            if (profile is null) throw new ArgumentNullException(nameof(profile));
+            if (profile.CalibrationMagic.Length == 0)
+                throw new InvalidOperationException($"No calibration magic pattern is recovered for {profile.Name}.");
+
+            return RunWithChannelAsync<object?>(async channel =>
+            {
+                var helper = new T6eUnlockHelper(channel, profile);
+                var writableTooling = new T6eToolingClient(channel, profile) { AllowWrites = true };
+                await helper.ApplyCalibrationMagicAsync(writableTooling, confirm: true, ct);
+                return null;
+            }, ct);
+        }
+
+        // Opens a temporary session + raw CAN channel with a pass-all filter, runs the body off the
+        // UI thread, and always disposes the session.
+        private static Task<T> RunWithChannelAsync<T>(Func<J2534Channel, Task<T>> body, CancellationToken ct)
+        {
             return Task.Run(async () =>
             {
                 using var session = J2534Session.Open();
                 J2534Channel channel = session.OpenCan();
 
-                // Pass every 11-bit CAN ID; the clients filter to their response IDs in software.
                 var passAll = new MessageFilter
                 {
                     FilterType = Filter.PASS_FILTER,
@@ -33,8 +88,7 @@ namespace LotusECMLogger.Services
                 };
                 channel.StartMessageFilter(passAll).ThrowIfError();
 
-                var helper = new T6eUnlockHelper(channel, profile);
-                return await helper.ProbeAsync(ct);
+                return await body(channel);
             }, ct);
         }
     }

--- a/LotusECMLogger/Services/IEngineeringAccessService.cs
+++ b/LotusECMLogger/Services/IEngineeringAccessService.cs
@@ -3,11 +3,20 @@ using System.Threading.Tasks;
 
 namespace LotusECMLogger.Services
 {
+    /// <summary>Which protocol a UI-initiated engineering write should use.</summary>
+    public enum EngineeringWriteTransport
+    {
+        /// <summary>Proprietary tooling channel (0x202). Works even when the ECU is locked.</summary>
+        ToolingChannel,
+
+        /// <summary>Raw RMA engineering family (0x40-0x47 / 0x50-0x57). Serviced only when unlocked.</summary>
+        RmaFamily,
+    }
+
     /// <summary>
-    /// Runs the read-only engineering-access probes (RMA engineering family, proprietary tooling
-    /// channel, and calibration-shadow predicate) against a chosen ECU profile and returns a
-    /// combined report. Opens and closes its own J2534 CAN session per call, so it must not run
-    /// while the main logger owns the device.
+    /// Runs the read-only engineering-access probes and — when the caller explicitly opts in —
+    /// the write operations, against a chosen ECU profile. Opens and closes its own J2534 CAN
+    /// session per call, so it must not run while the main logger owns the device.
     /// </summary>
     public interface IEngineeringAccessService
     {
@@ -16,5 +25,19 @@ namespace LotusECMLogger.Services
 
         /// <summary>Opens a temporary CAN channel, runs the read-only probes, and returns the report.</summary>
         Task<UnlockProbeReport> ProbeAsync(EcuMemoryProfile profile, CancellationToken ct = default);
+
+        /// <summary>
+        /// Writes <paramref name="data"/> to <paramref name="address"/> on the ECU using the chosen
+        /// transport. This is a live memory write; the caller is responsible for confirmation.
+        /// </summary>
+        Task WriteAsync(EcuMemoryProfile profile, EngineeringWriteTransport transport, uint address, byte[] data, CancellationToken ct = default);
+
+        /// <summary>
+        /// Writes each of the profile's calibration-shadow magic bytes to its expected value via the
+        /// tooling channel. Per the firmware analysis this does NOT re-run the boot predicate or
+        /// re-enable the mailbox interrupt in the same session — it exists to observe that behaviour.
+        /// Throws if the profile has no recovered magic pattern.
+        /// </summary>
+        Task ApplyCalibrationMagicAsync(EcuMemoryProfile profile, CancellationToken ct = default);
     }
 }

--- a/LotusECMLogger/Services/IEngineeringAccessService.cs
+++ b/LotusECMLogger/Services/IEngineeringAccessService.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LotusECMLogger.Services
+{
+    /// <summary>
+    /// Runs the read-only engineering-access probes (RMA engineering family, proprietary tooling
+    /// channel, and calibration-shadow predicate) against a chosen ECU profile and returns a
+    /// combined report. Opens and closes its own J2534 CAN session per call, so it must not run
+    /// while the main logger owns the device.
+    /// </summary>
+    public interface IEngineeringAccessService
+    {
+        /// <summary>The ECU profiles the UI can target.</summary>
+        IReadOnlyList<EcuMemoryProfile> AvailableProfiles { get; }
+
+        /// <summary>Opens a temporary CAN channel, runs the read-only probes, and returns the report.</summary>
+        Task<UnlockProbeReport> ProbeAsync(EcuMemoryProfile profile, CancellationToken ct = default);
+    }
+}

--- a/LotusECMLogger/Services/T6eToolingClient.cs
+++ b/LotusECMLogger/Services/T6eToolingClient.cs
@@ -1,0 +1,223 @@
+using System.Buffers.Binary;
+using System.Threading;
+using System.Threading.Tasks;
+using SAE.J2534;
+
+namespace LotusECMLogger.Services
+{
+    /// <summary>
+    /// Diagnostic client for the ECU's proprietary "tooling" CAN channel
+    /// (Emira: request 0x202, responses 0x200/0x201). This channel is initialized
+    /// independently of the raw memory family (0x40-0x47 / 0x50-0x57), so probing it is a
+    /// useful way to check what diagnostic access a given ECU exposes.
+    ///
+    /// Protocol recovered from disassembly/emira/8896915220A_ROW/emira.c:
+    ///   • Receive (flexcan_c_rx_202 → FUN_00a058dc): a request is accepted ONLY when the
+    ///     CAN frame carries a full DLC of 8. The eight data bytes are copied into a command
+    ///     record and executed by the periodic interpreter (FUN_00a04eec).
+    ///   • Command record layout (the 8 data bytes):
+    ///         [0] opcode
+    ///         [1] echo tag (returned in the reply so requests can be correlated)
+    ///         [2] length / sub-command
+    ///         [3] first inline payload byte
+    ///         [4..7] 32-bit parameter, big-endian (address for set-pointer / read-at)
+    ///   • Reply (on 0x200 or 0x201), 8 bytes: [0]=0xFF marker, [1]=status (0 = OK, else an
+    ///     NRC-like code such as 0x30-0x33), [2]=echo tag, [3..] up to five result bytes.
+    ///
+    /// Decoded opcodes used here:
+    ///   0x02 set pointer register N (N = byte[2] ∈ {0,1}) to the big-endian address in [4..7]
+    ///   0x03 write byte[2] payload bytes (from [3]) through pointer 0, advancing it
+    ///   0x04 read byte[2] bytes through pointer 0 into the reply, advancing it
+    ///   0x09 version / current calibration-base marker
+    ///   0x0F read byte[2] bytes starting at the big-endian address in [4..7] (one-shot read)
+    ///
+    /// A single frame moves at most five payload bytes, so this channel is for probing and
+    /// small reads, not bulk transfer — use the RMA path for dumps.
+    ///
+    /// SAFETY: the write opcode is included for completeness but, like the existing RMA write
+    /// path, is refused unless <see cref="AllowWrites"/> is explicitly set true.
+    /// </summary>
+    public sealed class T6eToolingClient
+    {
+        private const byte OpSetPointer = 0x02;
+        private const byte OpWriteThroughPointer = 0x03;
+        private const byte OpReadThroughPointer = 0x04;
+        private const byte OpVersion = 0x09;
+        private const byte OpReadAt = 0x0F;
+
+        private const byte ReplyMarker = 0xFF;
+        private const int MaxPayloadPerFrame = 5; // bytes [3..7] of the 8-byte record
+
+        private readonly J2534Channel _channel;
+        private readonly uint _requestId;
+        private readonly uint[] _responseIds;
+        private readonly TimeSpan _defaultTimeout;
+        private byte _tag;
+
+        /// <summary>When false (default), the write helper throws before touching the bus.</summary>
+        public bool AllowWrites { get; set; }
+
+        public T6eToolingClient(J2534Channel channel, EcuMemoryProfile profile, TimeSpan? defaultTimeout = null)
+            : this(channel, (profile ?? throw new ArgumentNullException(nameof(profile))).ToolingRequestId,
+                   profile.ToolingResponseIds, defaultTimeout)
+        {
+        }
+
+        public T6eToolingClient(J2534Channel channel, uint requestId, uint[] responseIds, TimeSpan? defaultTimeout = null)
+        {
+            _channel = channel ?? throw new ArgumentNullException(nameof(channel));
+            if (responseIds is null || responseIds.Length == 0)
+                throw new ArgumentException("At least one response ID is required.", nameof(responseIds));
+            _requestId = requestId;
+            _responseIds = responseIds;
+            _defaultTimeout = defaultTimeout ?? TimeSpan.FromMilliseconds(500);
+        }
+
+        /// <summary>
+        /// Queries the channel's version / calibration-base marker (opcode 0x09). This is the
+        /// safest liveness probe: a reply proves the tooling channel is reachable on this ECU
+        /// without any memory access. Returns null if the ECU stays silent.
+        /// </summary>
+        public async Task<ToolingReply?> GetVersionAsync(CancellationToken ct = default)
+        {
+            byte[] frame = BuildFrame(OpVersion, subOrLen: 0, address: 0, inlinePayload: default);
+            return await ExchangeAsync(frame, ct);
+        }
+
+        /// <summary>
+        /// Reads up to five bytes starting at <paramref name="address"/> using the one-shot
+        /// read-at opcode (0x0F).
+        /// </summary>
+        public async Task<byte[]> ReadAsync(uint address, int length, CancellationToken ct = default)
+        {
+            if (length < 1 || length > MaxPayloadPerFrame)
+                throw new ArgumentOutOfRangeException(nameof(length), $"Length must be 1..{MaxPayloadPerFrame} bytes per frame.");
+
+            byte[] frame = BuildFrame(OpReadAt, subOrLen: (byte)length, address: address, inlinePayload: default);
+            ToolingReply reply = await ExchangeAsync(frame, ct)
+                ?? throw new TimeoutException($"No tooling-channel reply to read at 0x{address:X8}.");
+            reply.ThrowIfError();
+            return reply.Data.Length >= length ? reply.Data[..length] : reply.Data;
+        }
+
+        /// <summary>Sets pointer register <paramref name="register"/> (0 or 1) to an address (opcode 0x02).</summary>
+        public async Task SetPointerAsync(byte register, uint address, CancellationToken ct = default)
+        {
+            if (register > 1) throw new ArgumentOutOfRangeException(nameof(register), "Only pointer registers 0 and 1 exist.");
+            byte[] frame = BuildFrame(OpSetPointer, subOrLen: register, address: address, inlinePayload: default);
+            ToolingReply? reply = await ExchangeAsync(frame, ct);
+            reply?.ThrowIfError();
+        }
+
+        /// <summary>Reads up to five bytes through pointer 0, advancing it (opcode 0x04).</summary>
+        public async Task<byte[]> ReadThroughPointerAsync(int length, CancellationToken ct = default)
+        {
+            if (length < 1 || length > MaxPayloadPerFrame)
+                throw new ArgumentOutOfRangeException(nameof(length), $"Length must be 1..{MaxPayloadPerFrame} bytes per frame.");
+            byte[] frame = BuildFrame(OpReadThroughPointer, subOrLen: (byte)length, address: 0, inlinePayload: default);
+            ToolingReply reply = await ExchangeAsync(frame, ct)
+                ?? throw new TimeoutException("No tooling-channel reply to pointer read.");
+            reply.ThrowIfError();
+            return reply.Data.Length >= length ? reply.Data[..length] : reply.Data;
+        }
+
+        /// <summary>
+        /// Points pointer register 0 at <paramref name="address"/> (opcode 0x02) then writes the
+        /// supplied bytes through it (opcode 0x03). Gated by <see cref="AllowWrites"/>, mirroring
+        /// the existing RMA write path.
+        /// </summary>
+        public async Task WriteAsync(uint address, ReadOnlyMemory<byte> data, CancellationToken ct = default)
+        {
+            if (!AllowWrites)
+                throw new InvalidOperationException(
+                    "Tooling-channel writes are disabled. Set AllowWrites = true to permit them (same guard as RMA writes).");
+            if (data.Length < 1 || data.Length > MaxPayloadPerFrame)
+                throw new ArgumentOutOfRangeException(nameof(data), $"Write payload must be 1..{MaxPayloadPerFrame} bytes per frame.");
+
+            await SetPointerAsync(0, address, ct);
+            byte[] frame = BuildFrame(OpWriteThroughPointer, subOrLen: (byte)data.Length, address: 0, inlinePayload: data.Span);
+            ToolingReply? reply = await ExchangeAsync(frame, ct);
+            reply?.ThrowIfError();
+        }
+
+        private byte[] BuildFrame(byte opcode, byte subOrLen, uint address, ReadOnlySpan<byte> inlinePayload)
+        {
+            // Every request is a full 8-byte-DLC frame; the firmware discards anything shorter.
+            byte[] data = new byte[8];
+            data[0] = opcode;
+            data[1] = _tag = unchecked((byte)(_tag + 1)); // rolling echo tag for correlation
+            data[2] = subOrLen;
+            if (!inlinePayload.IsEmpty)
+                inlinePayload.CopyTo(data.AsSpan(3, Math.Min(inlinePayload.Length, MaxPayloadPerFrame)));
+            else
+                BinaryPrimitives.WriteUInt32BigEndian(data.AsSpan(4, 4), address);
+            return data;
+        }
+
+        private async Task<ToolingReply?> ExchangeAsync(byte[] data8, CancellationToken ct)
+        {
+            byte expectedTag = data8[1];
+            Send(_requestId, data8);
+
+            var deadline = DateTime.UtcNow + _defaultTimeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                var res = _channel.ReadMessage();
+                if (res.Status == ResultCode.STATUS_NOERROR && res.Messages is { Length: > 0 })
+                {
+                    foreach (var m in res.Messages)
+                    {
+                        if (TryParseReply(m, expectedTag, out ToolingReply reply))
+                            return reply;
+                    }
+                }
+                await Task.Delay(1, ct);
+            }
+            return null;
+        }
+
+        private bool TryParseReply(in SAE.J2534.Message m, byte expectedTag, out ToolingReply reply)
+        {
+            reply = default;
+            if (m.Data is null || m.Data.Length <= 4) return false;
+
+            uint id = BinaryPrimitives.ReadUInt32BigEndian(m.Data.AsSpan(0, 4));
+            if (Array.IndexOf(_responseIds, id) < 0) return false;
+
+            ReadOnlySpan<byte> payload = m.Data.AsSpan(4);
+            if (payload.Length < 3 || payload[0] != ReplyMarker) return false;
+
+            // Ignore stale replies that don't echo our request tag (best-effort correlation).
+            if (payload[2] != expectedTag) return false;
+
+            reply = new ToolingReply(
+                status: payload[1],
+                echoTag: payload[2],
+                data: payload.Length > 3 ? payload[3..].ToArray() : []);
+            return true;
+        }
+
+        private void Send(uint arbitrationId, ReadOnlySpan<byte> data)
+        {
+            var buf = new byte[4 + data.Length];
+            BinaryPrimitives.WriteUInt32BigEndian(buf.AsSpan(0, 4), arbitrationId);
+            data.CopyTo(buf.AsSpan(4));
+            _channel.SendMessage(new SAE.J2534.Message(buf, TxFlag.NONE));
+        }
+    }
+
+    /// <summary>A parsed reply from the tooling channel.</summary>
+    public readonly record struct ToolingReply(byte status, byte echoTag, byte[] data)
+    {
+        public byte Status => status;
+        public byte EchoTag => echoTag;
+        public byte[] Data => data;
+        public bool IsOk => status == 0;
+
+        public void ThrowIfError()
+        {
+            if (!IsOk)
+                throw new InvalidOperationException($"Tooling channel returned status 0x{status:X2} (non-zero = command rejected).");
+        }
+    }
+}

--- a/LotusECMLogger/Services/T6eUnlockHelper.cs
+++ b/LotusECMLogger/Services/T6eUnlockHelper.cs
@@ -1,0 +1,132 @@
+using System.Threading;
+using System.Threading.Tasks;
+using SAE.J2534;
+
+namespace LotusECMLogger.Services
+{
+    /// <summary>Result of reading one calibration-shadow magic byte from a live ECU.</summary>
+    public readonly record struct MagicByteReading(uint Address, byte Expected, byte? Actual)
+    {
+        public bool Matches => Actual == Expected;
+        public bool Read => Actual.HasValue;
+    }
+
+    /// <summary>Snapshot of what a given ECU exposes, gathered by <see cref="T6eUnlockHelper"/>.</summary>
+    public sealed record UnlockProbeReport
+    {
+        public required string ProfileName { get; init; }
+
+        /// <summary>The raw engineering memory family answered a read (ecu_unlocked was true at boot).</summary>
+        public bool EngineeringAccessLive { get; init; }
+
+        /// <summary>The proprietary tooling channel answered a version query.</summary>
+        public bool ToolingChannelReachable { get; init; }
+
+        /// <summary>Per-byte state of the calibration-shadow predicate (empty if not recovered for this ECU).</summary>
+        public IReadOnlyList<MagicByteReading> CalibrationMagic { get; init; } = [];
+
+        /// <summary>All recovered magic bytes are present and match — the boot predicate would pass.</summary>
+        public bool CalibrationMagicComplete =>
+            CalibrationMagic.Count > 0 && CalibrationMagic.All(b => b.Matches);
+    }
+
+    /// <summary>
+    /// High-level helper for inspecting the engineering-access state of a T6-family ECU on the
+    /// bench. It combines three read-only signals:
+    ///   1. does the raw memory family answer (i.e. is <c>ecu_unlocked</c> true) — via RMA;
+    ///   2. is the un-gated tooling channel reachable — via a tooling version query;
+    ///   3. what do the four calibration-shadow bytes currently hold — read through the tooling
+    ///      channel, which the firmware services regardless of the engineering gate.
+    ///
+    /// It also offers an OPT-IN patch of those four bytes. Per
+    /// disassembly/emira/8896915220A_ROW/analysis/ENGINEERING_UNLOCK_PATHS.md, patching the RAM
+    /// shadow does NOT re-run the boot predicate or re-enable the mailbox interrupt in the same
+    /// session — persistent enablement requires a calibration reflash. The patch here exists so
+    /// you can observe that behaviour directly, not because it is expected to unlock live.
+    /// </summary>
+    public sealed class T6eUnlockHelper
+    {
+        private readonly EcuMemoryProfile _profile;
+        private readonly T6eRMAClient _rma;
+        private readonly T6eToolingClient _tooling;
+
+        public T6eUnlockHelper(J2534Channel channel, EcuMemoryProfile profile, TimeSpan? timeout = null)
+        {
+            _profile = profile ?? throw new ArgumentNullException(nameof(profile));
+            _rma = new T6eRMAClient(channel, profile, timeout);
+            _tooling = new T6eToolingClient(channel, profile, timeout);
+        }
+
+        /// <summary>Runs all three read-only probes and returns a combined report.</summary>
+        public async Task<UnlockProbeReport> ProbeAsync(CancellationToken ct = default)
+        {
+            bool engineering = await _rma.ProbeEngineeringAccessAsync(ct);
+
+            bool tooling;
+            try { tooling = await _tooling.GetVersionAsync(ct) is not null; }
+            catch { tooling = false; }
+
+            IReadOnlyList<MagicByteReading> magic = tooling
+                ? await ReadCalibrationMagicAsync(ct)
+                : [];
+
+            return new UnlockProbeReport
+            {
+                ProfileName = _profile.Name,
+                EngineeringAccessLive = engineering,
+                ToolingChannelReachable = tooling,
+                CalibrationMagic = magic,
+            };
+        }
+
+        /// <summary>
+        /// Reads the four calibration-shadow magic bytes through the tooling channel and reports
+        /// whether each matches its expected value. Returns an empty list when the pattern for the
+        /// active profile has not been recovered.
+        /// </summary>
+        public async Task<IReadOnlyList<MagicByteReading>> ReadCalibrationMagicAsync(CancellationToken ct = default)
+        {
+            var readings = new List<MagicByteReading>();
+            foreach (var b in _profile.CalibrationMagic)
+            {
+                if (_profile.MagicAddress(b) is not uint addr)
+                    continue;
+
+                byte? actual;
+                try
+                {
+                    byte[] bytes = await _tooling.ReadAsync(addr, 1, ct);
+                    actual = bytes.Length > 0 ? bytes[0] : null;
+                }
+                catch (OperationCanceledException) { throw; }
+                catch { actual = null; }
+
+                readings.Add(new MagicByteReading(addr, b.ExpectedValue, actual));
+            }
+            return readings;
+        }
+
+        /// <summary>
+        /// Writes the expected value into each calibration-shadow magic byte via the tooling
+        /// channel. Requires <paramref name="confirm"/> = true AND the tooling client's
+        /// <see cref="T6eToolingClient.AllowWrites"/> enabled by the caller. See the class remarks:
+        /// this is a diagnostic experiment, not an expected live unlock.
+        /// </summary>
+        public async Task ApplyCalibrationMagicAsync(T6eToolingClient writableTooling, bool confirm, CancellationToken ct = default)
+        {
+            if (!confirm)
+                throw new InvalidOperationException("Refusing to patch calibration-shadow bytes without explicit confirmation.");
+            if (writableTooling is null)
+                throw new ArgumentNullException(nameof(writableTooling));
+            if (_profile.CalibrationMagic.Length == 0)
+                throw new InvalidOperationException($"No calibration magic pattern is recovered for {_profile.Name}.");
+
+            foreach (var b in _profile.CalibrationMagic)
+            {
+                if (_profile.MagicAddress(b) is not uint addr)
+                    continue;
+                await writableTooling.WriteAsync(addr, new[] { b.ExpectedValue }, ct);
+            }
+        }
+    }
+}

--- a/LotusECMLogger/T6eRMAClient.cs
+++ b/LotusECMLogger/T6eRMAClient.cs
@@ -1,31 +1,71 @@
 using System.Buffers.Binary;
 using System.Threading;
 using System.Threading.Tasks;
+using LotusECMLogger.Services;
 using SAE.J2534;
 
 namespace LotusECMLogger
 {
     /// <summary>
-    /// T6e Remote Memory Access client. Implements the ECU's CAN-based memory R/W protocol
-    /// using standard IDs 0x50-0x57 and response aggregation on a configurable response ID.
+    /// T6e Remote Memory Access client. Implements the ECU's CAN-based memory R/W protocol.
+    /// The eight operations are laid out contiguously from a base ID (Evora 0x50, Emira 0x40):
+    /// +0 read32, +1 read16, +2 read8, +3 block read, +4 write32, +5 write16, +6 write8,
+    /// +7 block write. Every read is answered on the profile's response ID (0x7A0 on both ECUs).
+    ///
+    /// This family is gated by the firmware's <c>ecu_unlocked</c> boot predicate: reads are only
+    /// serviced when the ECU is unlocked, which is exactly what <see cref="ProbeEngineeringAccessAsync"/>
+    /// exploits — a reply means the family is live, silence means locked (or ECU absent).
+    ///
+    /// SAFETY: writes are refused unless <see cref="AllowWrites"/> is set true.
     /// </summary>
     public sealed class T6eRMAClient
     {
-        public const uint IdRead32 = 0x50;
-        public const uint IdRead   = 0x53; // block read
-        public const uint IdWrite32 = 0x54;
-        public const uint IdWrite   = 0x57; // block write
-
         private readonly J2534Channel _channel;
+        private readonly EcuMemoryProfile _profile;
         private readonly uint _responseId;
         private readonly TimeSpan _defaultTimeout;
 
-        public T6eRMAClient(J2534Channel channel, uint responseId = 0x1E8, TimeSpan? defaultTimeout = null)
+        private uint IdRead32 => _profile.RmaBaseId + 0;
+        private uint IdRead   => _profile.RmaBaseId + 3; // block read
+        private uint IdWrite32 => _profile.RmaBaseId + 4;
+        private uint IdWrite   => _profile.RmaBaseId + 7; // block write
+
+        /// <summary>When false (default), every write helper throws before touching the bus.</summary>
+        public bool AllowWrites { get; set; }
+
+        public T6eRMAClient(J2534Channel channel, EcuMemoryProfile profile, TimeSpan? defaultTimeout = null)
         {
             _channel = channel ?? throw new ArgumentNullException(nameof(channel));
-            _responseId = responseId;
+            _profile = profile ?? throw new ArgumentNullException(nameof(profile));
+            _responseId = profile.RmaResponseId;
             _defaultTimeout = defaultTimeout ?? TimeSpan.FromMilliseconds(500);
-            throw new NotImplementedException("This class has not yet been tested. Remove this error and proceed with caution.");
+        }
+
+        /// <summary>
+        /// Probes whether the raw engineering memory family is currently live (i.e. the ECU's
+        /// <c>ecu_unlocked</c> predicate passed at boot) by issuing a single read32 at the base
+        /// of the RAM window and waiting briefly for a reply on the response ID. A reply => the
+        /// family is enabled; silence => locked or no ECU. Read-only and side-effect free.
+        /// </summary>
+        public async Task<bool> ProbeEngineeringAccessAsync(CancellationToken ct = default)
+        {
+            try
+            {
+                byte[] req = new byte[4];
+                BinaryPrimitives.WriteUInt32BigEndian(req, _profile.RamStart);
+                Send(IdRead32, req);
+                var msg = await ReceiveAsync(m => HasId(m, _responseId) && GetPayload(m).Length > 0,
+                    TimeSpan.FromMilliseconds(150), ct);
+                return msg != null;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         public async Task<uint> ReadU32(uint address, CancellationToken ct = default)
@@ -33,7 +73,7 @@ namespace LotusECMLogger
             ValidateRange(address, 4);
             byte[] req = new byte[4];
             BinaryPrimitives.WriteUInt32BigEndian(req, address);
-            await SendAsync(IdRead32, req, ct);
+            Send(IdRead32, req);
             var payload = await ReceivePayloadExactAsync(4, ct);
             return BinaryPrimitives.ReadUInt32BigEndian(payload);
         }
@@ -48,14 +88,14 @@ namespace LotusECMLogger
                 byte[] hdr = new byte[5];
                 BinaryPrimitives.WriteUInt32BigEndian(hdr, address);
                 hdr[4] = (byte)length;
-                await SendAsync(IdRead, hdr.ToArray(), ct);
+                Send(IdRead, hdr);
             }
             else
             {
                 byte[] hdr = new byte[6];
                 BinaryPrimitives.WriteUInt32BigEndian(hdr, address);
-                BinaryPrimitives.WriteUInt16BigEndian(hdr[4..], (ushort)length);
-                await SendAsync(IdRead, hdr.ToArray(), ct);
+                BinaryPrimitives.WriteUInt16BigEndian(hdr.AsSpan(4), (ushort)length);
+                Send(IdRead, hdr);
             }
 
             byte[] result = new byte[length];
@@ -71,35 +111,45 @@ namespace LotusECMLogger
             return result;
         }
 
-        public async Task WriteU32(uint address, uint value, CancellationToken ct = default)
+        public Task WriteU32(uint address, uint value, CancellationToken ct = default)
         {
+            RequireWrites();
             ValidateRange(address, 4);
             byte[] payload = new byte[8];
             BinaryPrimitives.WriteUInt32BigEndian(payload, address);
-            BinaryPrimitives.WriteUInt32BigEndian(payload[4..], value);
-            await SendAsync(IdWrite32, payload.ToArray(), ct);
+            BinaryPrimitives.WriteUInt32BigEndian(payload.AsSpan(4), value);
+            Send(IdWrite32, payload);
+            return Task.CompletedTask;
         }
 
-        public async Task Write(uint address, ReadOnlyMemory<byte> data, CancellationToken ct = default)
+        public Task Write(uint address, ReadOnlyMemory<byte> data, CancellationToken ct = default)
         {
+            RequireWrites();
             if (data.Length <= 0) throw new ArgumentOutOfRangeException(nameof(data));
             ValidateRange(address, (uint)data.Length);
 
-            // Protocol supports only an 8-bit length header for block write (0x57)
+            // Protocol supports only an 8-bit length header for block write.
             if (data.Length > 0xFF) throw new ArgumentOutOfRangeException(nameof(data), "Block write supports up to 255 bytes per header.");
 
             byte[] hdr = new byte[5];
             BinaryPrimitives.WriteUInt32BigEndian(hdr, address);
             hdr[4] = (byte)data.Length;
-            await SendAsync(IdWrite, hdr.ToArray(), ct);
+            Send(IdWrite, hdr);
 
             int offset = 0;
             while (offset < data.Length)
             {
                 int chunk = Math.Min(8, data.Length - offset);
-                await SendAsync(IdWrite, data.Slice(offset, chunk), ct);
+                Send(IdWrite, data.Slice(offset, chunk).Span);
                 offset += chunk;
             }
+            return Task.CompletedTask;
+        }
+
+        private void RequireWrites()
+        {
+            if (!AllowWrites)
+                throw new InvalidOperationException("RMA writes are disabled. Set AllowWrites = true to permit them.");
         }
 
         private async Task<byte[]> ReceivePayloadExactAsync(int expectedLen, CancellationToken ct)
@@ -118,15 +168,12 @@ namespace LotusECMLogger
             return msg.Value;
         }
 
-        private Task SendAsync(uint arbitrationId, ReadOnlyMemory<byte> data, CancellationToken ct)
+        private void Send(uint arbitrationId, ReadOnlySpan<byte> data)
         {
-            // Build message buffer: [4 bytes arbId BE][payload]
             var buf = new byte[4 + data.Length];
             BinaryPrimitives.WriteUInt32BigEndian(buf.AsSpan(0, 4), arbitrationId);
-            data.CopyTo(buf.AsMemory(4));
-            var msg = new SAE.J2534.Message(buf, TxFlag.NONE);
-            _channel.SendMessage(msg);
-            return Task.CompletedTask;
+            data.CopyTo(buf.AsSpan(4));
+            _channel.SendMessage(new SAE.J2534.Message(buf, TxFlag.NONE));
         }
 
         private async Task<SAE.J2534.Message?> ReceiveAsync(Func<SAE.J2534.Message, bool> match, TimeSpan timeout, CancellationToken ct)
@@ -159,13 +206,11 @@ namespace LotusECMLogger
             return new ReadOnlyMemory<byte>(m.Data, 4, m.Data.Length - 4);
         }
 
-        private static void ValidateRange(uint addr, uint len)
+        private void ValidateRange(uint addr, uint len)
         {
-            bool low = addr < 0x0010_0000 && (ulong)addr + len <= 0x0010_0000UL;
-            bool high = addr >= 0x4000_0000 && (ulong)addr + len <= 0x4001_0000UL;
-            if (!(low || high)) throw new ArgumentOutOfRangeException(nameof(addr), "Address out of allowed ECU windows");
+            bool ok = addr >= _profile.RamStart && (ulong)addr + len <= (ulong)_profile.RamEnd + 1;
+            if (!ok) throw new ArgumentOutOfRangeException(nameof(addr),
+                $"Address 0x{addr:X8} (+{len}) is outside the {_profile.Name} window 0x{_profile.RamStart:X8}-0x{_profile.RamEnd:X8}.");
         }
     }
 }
-
-


### PR DESCRIPTION
## Summary

Adds tooling for inspecting — and optionally exercising — the T6-family ECU's engineering/diagnostic access paths, derived from the Emira firmware analysis in the LotusECU-T4e repo (`disassembly/emira/8896915220A_ROW/analysis/`). The goal is to be able to answer, on a real ECU: **is the engineering memory family live, is the proprietary tooling channel reachable, and what do the calibration-shadow "unlock" bytes currently hold** — and then, if you opt in, to read/write memory through those channels.

Ships as a set of protocol clients plus a new **Engineering Access** tab that drives them, so it can be used without writing calling code.

## Background: the two engineering surfaces

From the firmware analysis, the ECU exposes two independent proprietary CAN surfaces:

1. **Raw memory family** (Evora `0x50–0x57`, Emira `0x40–0x47`, both replying on `0x7A0`). Gated by the boot-time `ecu_unlocked` predicate — the firmware only services these reads/writes when the ECU is "unlocked".
2. **Proprietary tooling channel** (`0x202` → `0x200/0x201`). Always initialized, **not** gated by `ecu_unlocked`, and capable of pointer-based memory read/write. This is the more interesting surface for probing what a locked ECU still exposes.

`ecu_unlocked` itself is set at boot only when four dispersed calibration-shadow bytes match fixed magic values (Emira: offsets `0xE2/0x218/0x290/0x337` = `0D/B8/45/D4`).

## What's included

### Protocol clients
- **`Services/EcuMemoryProfile.cs`** — configurable CAN IDs + memory layout, with `Evora` and `Emira` presets so one codebase targets either ECU. Carries the RMA base/response IDs, RAM window, tooling IDs, and (for Emira) the calibration-shadow base and magic bytes.
- **`Services/T6eToolingClient.cs`** — client for the `0x202` tooling channel. Opcodes decoded from `emira.c` (`0x09` version, `0x0F` read-at, `0x02` set-pointer, `0x04` read-through-pointer, `0x03` write). Enforces the firmware's DLC-8 requirement and parses the `[0xFF, status, echo, data…]` reply. Max 5 payload bytes per frame.
- **`T6eRMAClient.cs`** — reworked from a non-functional stub (it threw in its constructor) into a profile-driven, usable client, plus `ProbeEngineeringAccessAsync()` to detect the `ecu_unlocked` state.
- **`Services/T6eUnlockHelper.cs`** — combines the read-only signals into one `UnlockProbeReport` and offers an opt-in calibration-magic patch.

### UI — "Engineering Access" tab
- **`Services/IEngineeringAccessService` / `EngineeringAccessService`** — opens a short-lived raw CAN session (pass-all filter) per operation and drives the clients off the UI thread; same temporary-session pattern as `T6RMAService`.
- **`Controls/EngineeringAccessControl` (+Designer)** — the tab itself: a profile selector, a read-only probe, and an opt-in write section.
- **`MainWindow`** — new tab, tab icon, and logger-state propagation (the tab is disabled while the main logger owns the J2534 device).

All write paths in the clients are refused unless `AllowWrites = true` / `confirm: true`.

## How it works / what to expect

### Probe (read-only)
1. Pick an **ECU Profile** (Evora or Emira) and click **Run Probe**.
2. The service opens a temporary CAN channel and reports three signals:
   - **Engineering memory family (`ecu_unlocked`)**: a read on the RMA family is answered → LIVE (unlocked); silence → locked or ECU absent.
   - **Proprietary tooling channel**: a version query on `0x202` is answered → reachable.
   - **Calibration predicate**: a per-byte table of the four shadow bytes (address / expected / actual / match), read via the tooling channel (which works while locked).

Expected results:
- **Emira on a normal locked ECU**: engineering family = no response, tooling channel = reachable, calibration bytes readable and (on a stock cal) not matching the magic pattern.
- **Evora**: the tooling channel / magic-byte layout is a cross-model hypothesis, so the Evora profile ships with an empty magic pattern — the probe will show whether the channel answers and leave the predicate section blank. This is exactly the experiment: does the Evora expose the same `0x202` surface?

### Live memory write (opt-in)
The red **Live Memory Write** section stays disabled until you tick **"Enable writes"**. Then:
- Choose a **transport** — *Tooling channel* (`0x202`, works while locked) or *RMA family* (only when unlocked).
- Enter an **address** (hex) and **bytes** (hex — `0D B8 45 D4` or `0DB845D4`), click **Write Bytes**. A confirmation dialog shows exactly what will be written where before anything goes on the wire.
- **Apply Calibration Magic** writes all four shadow bytes to their expected values in one action (enabled only for a profile that has the pattern, i.e. Emira).

Important expectation, straight from the firmware analysis: **patching the calibration-shadow bytes at runtime does NOT unlock the ECU in the current session.** The four-byte predicate runs once during boot, and the mailbox interrupt for the engineering family is latched at init — writing the bytes afterward neither re-runs the predicate nor re-enables the mailbox. So after "Apply Calibration Magic" you should expect the bytes to read back as matching, but the engineering family to remain not-live until a reboot with a persistently-programmed calibration. The action exists to observe exactly that behaviour, not because it flips the gate live. The un-gated tooling channel, by contrast, gives live read/write on its own.

## Safety
- The probe is entirely read-only.
- Writes require the explicit "Enable writes" checkbox **and** a per-write confirmation dialog.
- The whole tab is blocked while the main logger is active, so the two can't contend for the J2534 device.

## Caveats
- **Not build-verified**: Windows-only WinForms project, authored on macOS. Please `dotnet build` on Windows against `J2534-Sharp.Core 2.0.4` before bench use. The client code mirrors the exact `J2534Session` / `MessageFilter` / `ThrowIfError` usage already in `T6RMAService`.
- The `0x202` channel details and calibration-magic offsets are **Emira-derived**; on the Evora they are a hypothesis the probe is designed to confirm or refute.

## Commits
1. Add T6e engineering-access probe clients (tooling channel + RMA)
2. Add Engineering Access probe tab UI
3. Add opt-in live-memory write to Engineering Access tab
